### PR TITLE
Change YAML parser for front matter, add metadata support, fix frontmatter + import incompat.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +37,12 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -94,6 +112,12 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "assert_fs"
@@ -747,6 +771,19 @@ name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
@@ -995,9 +1032,9 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
+ "saphyr",
  "serde",
  "serde_json",
- "serde_yaml",
  "tera",
  "thiserror",
  "walkdir",
@@ -1537,6 +1574,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31513a748cdf8fb8d1b64dcc14fdd997fa02f2431671c7ce34efbea5e7eeea"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+ "saphyr-parser",
+]
+
+[[package]]
+name = "saphyr-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123f0a6da68f3072c7c761450276d1d444cb391c8be182a757cd26cf684cb77f"
+dependencies = [
+ "arraydeque",
+ "hashlink",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,19 +1674,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2060,12 +2106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,4 +2427,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "f070617a68e5c2ed5d06ee8dd620ee18fb72b99f6c094bed34cf8ab07c875b48"
 dependencies = [
  "anstyle",
  "doc-comment",
- "globwalk",
+ "globwalk 0.8.1",
  "predicates",
  "predicates-core",
  "predicates-tree",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -743,6 +743,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
  "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.4.1",
  "ignore",
  "walkdir",
 ]
@@ -1830,13 +1841,13 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.19.1"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970dff17c11e884a4a09bc76e3a17ef71e01bb13447a11e85226e254fe6d10b8"
+checksum = "ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee"
 dependencies = [
  "chrono",
  "chrono-tz",
- "globwalk",
+ "globwalk 0.9.1",
  "humansize",
  "lazy_static",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ once_cell = "1.18.0"
 regex = "1.10.2"
 reqwest = { version = "0.11", features = ["blocking", "json", "multipart"] }
 ring = "0.17.7"
+saphyr = "0.0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.108"
-serde_yaml = "0.9.30"
 tera = "1.19.1"
 thiserror = "1.0.50"
 walkdir = "2.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ ring = "0.17.7"
 saphyr = "0.0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.108"
-tera = "1.19.1"
+tera = "1.20.0"
 thiserror = "1.0.50"
 walkdir = "2.4.0"

--- a/example/team/_tera/adr.md
+++ b/example/team/_tera/adr.md
@@ -1,0 +1,14 @@
+{% macro header_table() -%}
+
+<table>
+  <tr>
+    <th>Author</th>
+    <td>{{ metadata(path="author") }}</td>
+  </tr>
+  <tr>
+    <th>Status</th>
+    <td>{{ metadata(path="status") }}</td>
+  </tr>
+</table>
+
+{%- endmacro %}

--- a/example/team/metadata.md
+++ b/example/team/metadata.md
@@ -1,0 +1,18 @@
+---
+metadata:
+  author: Olivia
+  status: Approved
+emoji: heart_eyes
+imports:
+  - adr.md
+---
+
+# Metadata Example
+
+This example shows how to define a macro that uses metadata to generate a
+table.
+
+{{ adr::header_table() }}
+
+- [ ] task 1
+- [x] task 2

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -28,8 +28,8 @@ enum ParseState {
     InFrontMatter,
 }
 
-impl FrontMatter {
-    pub fn default() -> FrontMatter {
+impl Default for FrontMatter {
+    fn default() -> Self {
         FrontMatter {
             labels: Vec::default(),
             emoji: String::default(),
@@ -37,7 +37,9 @@ impl FrontMatter {
             unknown_keys: Vec::default(),
         }
     }
+}
 
+impl FrontMatter {
     #[cfg(test)]
     pub fn from_str(s: &str) -> Result<FrontMatter> {
         use std::io::Cursor;

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -1,0 +1,214 @@
+use std::io::Read;
+
+use saphyr::Yaml;
+
+use crate::Result;
+use thiserror::Error;
+
+// fn read_frontmatter_as_yaml(filename: &str) -> Yaml {
+//     Yaml::from_str("foo")
+// }
+
+#[derive(Error, Debug)]
+pub enum FrontMatterError {
+    #[error("Unable to parse front matter: {0}")]
+    ParseError(String),
+}
+
+#[derive(Debug)]
+pub struct FrontMatter {
+    pub labels: Vec<String>,
+    pub emoji: String,
+    pub metadata: Yaml,
+    pub unknown_keys: Vec<String>,
+}
+
+enum ParseState {
+    BeforeFrontMatter,
+    InFrontMatter,
+}
+
+impl FrontMatter {
+    pub fn default() -> FrontMatter {
+        FrontMatter {
+            labels: Vec::default(),
+            emoji: String::default(),
+            metadata: Yaml::Null,
+            unknown_keys: Vec::default(),
+        }
+    }
+
+    pub fn from_reader(reader: &impl Read) -> Result<FrontMatter> {
+        Ok(FrontMatter::default())
+    }
+
+    #[cfg(test)]
+    pub fn from_str(s: &str) -> Result<FrontMatter> {
+        use std::{
+            collections::HashSet,
+            io::{self, BufRead, Cursor},
+        };
+
+        use anyhow::Context;
+
+        let mut front_matter_str = String::new();
+        let mut state = ParseState::BeforeFrontMatter;
+        let cursor = Cursor::new(s);
+        let lines = io::BufReader::new(cursor).lines();
+        for line in lines.map_while(io::Result::ok) {
+            match state {
+                ParseState::BeforeFrontMatter => {
+                    let trimmed_line = line.trim();
+                    if trimmed_line == "---" {
+                        state = ParseState::InFrontMatter;
+                    } else if !trimmed_line.is_empty() {
+                        // found non frontmatter marker, assuming no front matter
+                        break;
+                    } else {
+                        // whitespace before front matter
+                    }
+                }
+                ParseState::InFrontMatter => {
+                    if line.starts_with("---") {
+                        break; // end of front matter
+                    } else {
+                        front_matter_str.push_str(&line);
+                        front_matter_str += "\n";
+                    }
+                }
+            }
+        }
+
+        if front_matter_str.is_empty() {
+            return Ok(FrontMatter::default());
+        }
+
+        let yaml_fm_docs = Yaml::load_from_str(&front_matter_str)
+            .context("Failed to parse front matter as YAML")?;
+        let yaml_fm = &yaml_fm_docs[0];
+        if !yaml_fm.is_hash() {
+            return Err(FrontMatterError::ParseError(String::from(
+                "Expected YAML hash map for front matter",
+            ))
+            .into());
+        }
+
+        static VALID_TOP_LEVEL_KEYS: [&str; 3] = ["emoji", "labels", "metadata"];
+        let string_keys: HashSet<&str> = yaml_fm
+            .as_hash()
+            .unwrap()
+            .iter()
+            .map(|(key, _value)| key.as_str().unwrap())
+            .collect();
+
+        let mut unknown_keys: Vec<String> = string_keys
+            .difference(&HashSet::from(VALID_TOP_LEVEL_KEYS))
+            .map(|s| s.to_string())
+            .collect();
+
+        unknown_keys.sort();
+        //
+        //                 if !unknown_keys.is_empty() {
+        //                     warnings.push(format!(
+        //                         "Unknown top level front matter keys: {}",
+        //                         unknown_keys.join(", "),
+        //                     ));
+        //                 }
+        //                 front_matter = yaml.clone();
+
+        println!("Yaml fm {:?}", yaml_fm);
+        let mut labels: Vec<String> = Vec::default();
+
+        if let Some(parsed_labels) = yaml_fm["labels"].as_vec().map(|v| {
+            v.iter()
+                .map(|l| String::from(l.as_str().unwrap()))
+                .collect::<Vec<String>>()
+        }) {
+            labels = parsed_labels;
+        }
+
+        let emoji = String::from(yaml_fm["emoji"].as_str().unwrap_or_default());
+        Ok(FrontMatter {
+            labels,
+            emoji,
+            metadata: yaml_fm["metadata"].clone(),
+            unknown_keys,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    static FRONT_MATTER_MD: &str = r##"---
+labels:
+- foo
+- bar
+emoji: heart_eyes
+metadata:
+    some:
+        arbitrary: "value"
+---
+# compulsory title
+{{ metadata.some.arbitrary }}
+"##;
+
+    static EMPTY_MD: &str = "# compulsory title\n";
+    static NOT_YAML_FRONT_MATTER_MD: &str = r##"---
+something = foo
+[section]
+gah = bar
+---
+# compulsory title
+"##;
+
+    use crate::error::TestResult;
+
+    use super::*;
+
+    #[test]
+    fn it_reads_frontmatter() -> TestResult {
+        let fm = FrontMatter::from_str(FRONT_MATTER_MD)?;
+
+        assert_eq!(fm.labels, vec!["foo", "bar"]);
+        assert_eq!(fm.emoji, "heart_eyes");
+        assert_eq!(fm.metadata["some"]["arbitrary"].as_str(), Some("value"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_returns_empty_frontmatter_if_not_present() -> TestResult {
+        let fm = FrontMatter::from_str(EMPTY_MD)?;
+        assert_eq!(fm.labels, Vec::<String>::default());
+        assert_eq!(fm.emoji, String::default());
+        assert!(fm.metadata.is_null());
+        Ok(())
+    }
+
+    #[test]
+    fn it_ignores_spaces_before_frontmatter() -> TestResult {
+        let fm = FrontMatter::from_str(&(String::from("\n   \n") + FRONT_MATTER_MD))?;
+        assert_eq!(fm.labels, vec!["foo", "bar"]);
+        assert_eq!(fm.emoji, "heart_eyes");
+        assert_eq!(fm.metadata["some"]["arbitrary"].as_str(), Some("value"));
+        Ok(())
+    }
+
+    #[test]
+    fn it_errors_if_not_yaml() -> TestResult {
+        let fm_result = FrontMatter::from_str(NOT_YAML_FRONT_MATTER_MD);
+
+        println!("{:?}", fm_result);
+
+        assert!(fm_result.is_err());
+        if let Err(err) = fm_result {
+            assert_eq!(
+                err.to_string(),
+                "Unable to parse front matter: Expected YAML hash map for front matter"
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1,0 +1,123 @@
+use std::path::Path;
+
+use crate::frontmatter::FrontMatter;
+
+pub fn generate_import_lines(fm: &FrontMatter) -> String {
+    fn generate_import_line(import: &String) -> String {
+        let import_path = Path::new(import);
+        let parent = if let Some(parent_path) = import_path.parent() {
+            let parent_str = parent_path.to_string_lossy().into_owned();
+            if parent_str.is_empty() {
+                parent_str
+            } else {
+                parent_str + "_"
+            }
+        } else {
+            String::new()
+        };
+        let namespace = Path::new(&import).file_stem().unwrap();
+        format!(
+            "{{% import '_tera/{}' as {} %}}\n",
+            import,
+            parent + &namespace.to_string_lossy()
+        )
+    }
+
+    fm.imports
+        .iter()
+        .map(generate_import_line)
+        .collect::<Vec<String>>()
+        .join("")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{error::TestResult, frontmatter::FrontMatter, template_renderer::TemplateRenderer};
+
+    use super::generate_import_lines;
+
+    static TEST_MACRO: &str = r##"
+{% macro test() -%}
+test passed
+{%- endmacro test %}
+"##;
+    #[test]
+    fn it_generates_import_lines() -> TestResult {
+        let fm1 = FrontMatter {
+            imports: vec![String::from("test.md")],
+            ..Default::default()
+        };
+
+        let import_lines = generate_import_lines(&fm1);
+        assert_eq!(import_lines, "{% import '_tera/test.md' as test %}\n");
+        Ok(())
+    }
+
+    #[test]
+    fn it_imports_macros_from_templates_specified_in_frontmatter() -> TestResult {
+        let fm1 = FrontMatter {
+            imports: vec![String::from("test.md")],
+            ..Default::default()
+        };
+
+        let mut template_renderer = TemplateRenderer::default()?;
+
+        template_renderer.add_raw_template("_tera/test.md", TEST_MACRO)?;
+
+        let result =
+            template_renderer.render_template_str("test.md", "{{ test::test() }}", &fm1)?;
+        assert_eq!(result, "test passed");
+        Ok(())
+    }
+
+    #[test]
+    fn it_errors_if_the_import_does_not_exist() -> TestResult {
+        let fm1 = FrontMatter {
+            imports: vec![String::from("does_not_exist.md")],
+            ..Default::default()
+        };
+
+        let mut template_renderer = TemplateRenderer::default()?;
+        let result = template_renderer.render_template_str("test.md", "{{ test::test() }}", &fm1);
+        assert!(result.is_err());
+        assert_eq!(
+            format!("{:?}", result),
+            "Err(Import 'does_not_exist.md' does not exist under the _tera directory)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn it_uses_the_basename_of_the_file_as_the_namespace() -> TestResult {
+        let fm1 = FrontMatter {
+            imports: vec![String::from("adr.md")],
+            ..Default::default()
+        };
+
+        let mut template_renderer = TemplateRenderer::default()?;
+
+        template_renderer.add_raw_template("_tera/adr.md", TEST_MACRO)?;
+
+        let result = template_renderer.render_template_str("test.md", "{{ adr::test() }}", &fm1);
+        assert!(result.is_ok());
+        assert_eq!(result?, "test passed");
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_handles_imports_from_subdirs() -> TestResult {
+        let fm1 = FrontMatter {
+            imports: vec![String::from("subdir/test.md")],
+            ..Default::default()
+        };
+
+        let mut template_renderer = TemplateRenderer::default()?;
+
+        template_renderer.add_raw_template("_tera/subdir/test.md", TEST_MACRO)?;
+        let result =
+            template_renderer.render_template_str("test.md", "{{ subdir_test::test() }}", &fm1);
+        assert_eq!(result?, "test passed");
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod confluence_storage_renderer;
 mod error;
 mod frontmatter;
 mod helpers;
+mod imports;
 mod link_generator;
 mod local_link;
 mod markdown_page;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod confluence_paginator;
 mod confluence_space;
 mod confluence_storage_renderer;
 mod error;
+mod frontmatter;
 mod helpers;
 mod link_generator;
 mod local_link;

--- a/src/markdown_page.rs
+++ b/src/markdown_page.rs
@@ -40,7 +40,7 @@ impl<'a> MarkdownPage<'a> {
         let fm = FrontMatter::from_reader(&file)?;
 
         let content = template_renderer
-            .render_template(&source)
+            .render_template(&source, &fm)
             .context(format!("Loading markdown from file {}", source))?;
         Self::parse_markdown(arena, source, markdown_page, &content, fm)
     }
@@ -55,7 +55,7 @@ impl<'a> MarkdownPage<'a> {
     ) -> Result<MarkdownPage<'a>> {
         let fm = FrontMatter::from_str(content)?;
         let content = template_renderer
-            .expand_html_str(source.as_str(), content, &fm)
+            .render_template_str(source.as_str(), content, &fm)
             .context(format!("Failed to render markdown from file {}", source))?;
         Self::parse_markdown(arena, source, markdown_page, &content, fm)
     }

--- a/src/markdown_page.rs
+++ b/src/markdown_page.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     fs::File,
     path::{Path, PathBuf},
 };

--- a/src/markdown_space.rs
+++ b/src/markdown_space.rs
@@ -97,6 +97,10 @@ impl<'a> MarkdownSpace<'a> {
                     &mut template_renderer,
                 )?;
 
+                for warning in markdown_page.warnings.iter() {
+                    println!("Warning: {}", warning);
+                }
+
                 link_generator.register_markdown_page(&markdown_page)?;
 
                 let missing_files: Vec<String> = markdown_page

--- a/src/page_emojis.rs
+++ b/src/page_emojis.rs
@@ -42,7 +42,9 @@ pub(crate) fn get_property_updates(
 
 pub(crate) fn parse_emoji(page: &MarkdownPage) -> Option<String> {
     let emoji_string = &page.front_matter.emoji;
-    if let Some(emoji) = emojis::get_by_shortcode(emoji_string) {
+    if emoji_string.is_empty() {
+        None
+    } else if let Some(emoji) = emojis::get_by_shortcode(emoji_string) {
         Some(format!(
             "{:x}",
             emoji.as_str().chars().next().unwrap() as u32

--- a/src/page_emojis.rs
+++ b/src/page_emojis.rs
@@ -41,9 +41,8 @@ pub(crate) fn get_property_updates(
 }
 
 pub(crate) fn parse_emoji(page: &MarkdownPage) -> Option<String> {
-    page.front_matter
-        .as_ref()
-        .and_then(|fm| fm.emoji.as_ref())
+    page.front_matter["emoji"]
+        .as_str()
         .and_then(|emoji_string| {
             if let Some(emoji) = emojis::get_by_shortcode(emoji_string) {
                 Some(format!(

--- a/src/page_emojis.rs
+++ b/src/page_emojis.rs
@@ -41,19 +41,16 @@ pub(crate) fn get_property_updates(
 }
 
 pub(crate) fn parse_emoji(page: &MarkdownPage) -> Option<String> {
-    page.front_matter["emoji"]
-        .as_str()
-        .and_then(|emoji_string| {
-            if let Some(emoji) = emojis::get_by_shortcode(emoji_string) {
-                Some(format!(
-                    "{:x}",
-                    emoji.as_str().chars().next().unwrap() as u32
-                ))
-            } else {
-                println!("Unknown short code '{}'", &emoji_string);
-                None
-            }
-        })
+    let emoji_string = &page.front_matter.emoji;
+    if let Some(emoji) = emojis::get_by_shortcode(emoji_string) {
+        Some(format!(
+            "{:x}",
+            emoji.as_str().chars().next().unwrap() as u32
+        ))
+    } else {
+        println!("Unknown short code '{}'", &emoji_string);
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -240,13 +240,11 @@ pub fn sync_space<'a>(
             &existing_page.id,
             &markdown_page.attachments,
         )?;
-        if let Some(labels) = &markdown_page.front_matter["labels"].as_vec().map(|v| {
-            v.iter()
-                .map(|l| String::from(l.as_str().unwrap()))
-                .collect::<Vec<String>>()
-        }) {
-            sync_page_labels(&confluence_client, &existing_page.id, labels)?;
-        }
+        sync_page_labels(
+            &confluence_client,
+            &existing_page.id,
+            &markdown_page.front_matter.labels,
+        )?;
         sync_page_properties(&confluence_client, markdown_page, &existing_page.id)?;
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -240,8 +240,12 @@ pub fn sync_space<'a>(
             &existing_page.id,
             &markdown_page.attachments,
         )?;
-        if let Some(front_matter) = &markdown_page.front_matter {
-            sync_page_labels(&confluence_client, &existing_page.id, &front_matter.labels)?;
+        if let Some(labels) = &markdown_page.front_matter["labels"].as_vec().map(|v| {
+            v.iter()
+                .map(|l| String::from(l.as_str().unwrap()))
+                .collect::<Vec<String>>()
+        }) {
+            sync_page_labels(&confluence_client, &existing_page.id, labels)?;
         }
         sync_page_properties(&confluence_client, markdown_page, &existing_page.id)?;
     }

--- a/src/template_renderer.rs
+++ b/src/template_renderer.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::thread::current;
 
 use saphyr::Yaml;
 use tera::{self, Tera, Value};


### PR DESCRIPTION
One my of my primary (personal) use cases for MarkedSpace is writing Architectural Decision Records (ADRs). These often have a header field that displays some control metadata such as status, approvers, consulted, etc. Because they're consistent, and only the data changes, I'd like to be able to separate the data from the presentation.

You can now write something like this:
```markdown
---
metadata:
   my_key: some value
---
# A test page

{{ metadata(path='my_key') }}
```

Obviously, it would have been great if I could have written `{{ metadata.my_key }}` instead, but unfortunately I also switched to [Saphyr](https://docs.rs/saphyr/latest/saphyr/) due to the previous YAML library I used [serde_yaml](https://docs.rs/serde_yaml/latest/serde_yaml/) becoming unmaintained 😢. Saphyr doesn't yet support serde, which integration with the templating engine Tera requires. Perhaps I will implement that soon. 