### PR TITLE
Retry rate limited (429) and transient requests to Confluence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 # Copy the Rust files
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo 'fn main() {}' > src/main.rs  # Dummy file to force dependency resolution
-RUN cargo fetch
+RUN cargo fetch --locked
 
 COPY .cargo ./.cargo
 COPY rustup-target-add.sh ./

--- a/README.md
+++ b/README.md
@@ -177,6 +177,32 @@ cargo run -- --space example/team
 cargo watch -x test
 ```
 
+## Rate Limiting and Retries
+
+Confluence Cloud rate limits its REST API, and a sync of a larger space can run
+into `429 Too Many Requests`. Marked-space retries these automatically: it waits
+for the period the server asks for in the `Retry-After` header, or falls back to
+an exponential backoff with jitter (500ms, then 1s, 2s, 4s..., capped at 60s).
+Transient server errors (5xx) and dropped connections are retried the same way,
+but only for requests that can't be duplicated by repeating them, so a failed
+page creation is never retried blindly.
+
+Retries are reported as they happen, for example:
+
+```text
+warning: GET /wiki/api/v2/pages/12345/properties: rate limited by Confluence (429). Retrying in 2.0s (3/8).
+```
+
+The defaults (8 retries) suit most spaces. If a sync still gives up while rate
+limited, allow more retries or slow the backoff down:
+
+| Setting                                 | Default | Description                                   |
+| --------------------------------------- | ------- | --------------------------------------------- |
+| `--max-retries`                         | 8       | Retries after the initial attempt             |
+| `$MARKED_SPACE_MAX_RETRIES`             | 8       | As above, for when a flag is inconvenient     |
+| `$MARKED_SPACE_RETRY_INITIAL_BACKOFF_MS`| 500     | Wait before the first retry, in milliseconds  |
+| `$MARKED_SPACE_RETRY_MAX_BACKOFF_SECS`  | 60      | Longest single wait, in seconds               |
+
 ## Further Reading
 
 Checkout the user guide in the [example space](example/team/index.md)... this

--- a/rustup-target-add.sh
+++ b/rustup-target-add.sh
@@ -12,5 +12,7 @@ fi
 
 rustup target add $CARGO_TARGET
 
-# use install here so we don't have to map in the run images
-cargo install --target $CARGO_TARGET --path .
+# use install here so we don't have to map in the run images.
+# --locked builds the versions in Cargo.lock: cargo install otherwise re-resolves
+# dependencies, and picks up releases that need a newer rustc than the image has.
+cargo install --locked --target $CARGO_TARGET --path .

--- a/src/attachments.rs
+++ b/src/attachments.rs
@@ -16,7 +16,6 @@ use std::{
 use anyhow::Context;
 use comrak::nodes::NodeLink;
 use regex::Regex;
-use reqwest::blocking::multipart::Part;
 
 use crate::{
     confluence_client::ConfluenceClient,
@@ -147,12 +146,12 @@ pub fn sync_page_attachments(
             return Ok(());
         }
 
-        let file_part = Part::file(&attachment.link.target)
-            .context(format!("Opening {}", attachment.link.target.display()))?
-            .file_name(attachment.link.attachment_name());
-
-        let response =
-            confluence_client.create_or_update_attachment(page_id, file_part, &hashstring)?;
+        let response = confluence_client.create_or_update_attachment(
+            page_id,
+            &attachment.link.target,
+            &attachment_name,
+            &hashstring,
+        )?;
 
         if !response.status().is_success() {
             // Handle non-2xx responses (e.g., 400 Bad Request)

--- a/src/confluence_client.rs
+++ b/src/confluence_client.rs
@@ -1,8 +1,20 @@
 #![allow(dead_code)]
 
+use anyhow::Context;
 use reqwest::blocking::multipart::{Form, Part};
+use reqwest::blocking::RequestBuilder;
+use reqwest::Method;
 use serde_json::{json, Value};
 use std::env;
+use std::path::Path;
+use std::thread::sleep;
+use std::time::Duration;
+
+use crate::console::{print_error, print_warning};
+use crate::retry::{classify_error, classify_status, retry_after, RetryConfig};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Clone)]
 pub struct ConfluenceClient {
@@ -11,18 +23,29 @@ pub struct ConfluenceClient {
     api_token: String,
     pub hostname: String,
     insecure: bool,
+    retry: RetryConfig,
 }
 
-pub type Result = anyhow::Result<reqwest::blocking::Response, reqwest::Error>;
+pub type Result = anyhow::Result<reqwest::blocking::Response>;
+
+fn http_client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .user_agent(concat!("marked-space/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .unwrap_or_else(|_| reqwest::blocking::Client::new())
+}
 
 impl ConfluenceClient {
     pub fn new(hostname: &str) -> ConfluenceClient {
         ConfluenceClient {
             api_user: env::var("API_USER").unwrap_or_default(),
             api_token: env::var("API_TOKEN").unwrap_or_default(),
-            client: reqwest::blocking::Client::new(),
+            client: http_client(),
             hostname: String::from(hostname),
             insecure: false,
+            retry: RetryConfig::from_env(),
         }
     }
 
@@ -31,388 +54,378 @@ impl ConfluenceClient {
         ConfluenceClient {
             api_user: env::var("API_USER").unwrap_or_default(),
             api_token: env::var("API_TOKEN").unwrap_or_default(),
-            client: reqwest::blocking::Client::new(),
+            client: http_client(),
             hostname: String::from(hostname),
             insecure: true,
+            // Tests shouldn't spend real time waiting between retries.
+            retry: RetryConfig {
+                max_retries: 3,
+                initial_backoff: Duration::from_millis(1),
+                max_backoff: Duration::from_millis(5),
+            },
+        }
+    }
+
+    pub fn with_retry_config(mut self, retry: RetryConfig) -> ConfluenceClient {
+        self.retry = retry;
+        self
+    }
+
+    fn scheme(&self) -> &str {
+        if self.insecure {
+            "http"
+        } else {
+            "https"
         }
     }
 
     fn rest_api(&self, p: &str) -> String {
-        format!(
-            "{}://{}/wiki/rest/api/{}",
-            if self.insecure { "http" } else { "https" },
-            self.hostname,
-            p
-        )
+        format!("{}://{}/wiki/rest/api/{}", self.scheme(), self.hostname, p)
     }
 
     fn rest_api_v2(&self, p: &str) -> String {
-        format!(
-            "{}://{}/wiki/api/v2/{}",
-            if self.insecure { "http" } else { "https" },
-            self.hostname,
-            p
-        )
+        format!("{}://{}/wiki/api/v2/{}", self.scheme(), self.hostname, p)
     }
 
     fn graphql_api(&self) -> String {
-        format!(
-            "{}://{}/cgraphql",
-            if self.insecure { "http" } else { "https" },
-            self.hostname
-        )
+        format!("{}://{}/cgraphql", self.scheme(), self.hostname)
+    }
+
+    /// Start a request with authentication and the headers every endpoint needs.
+    fn request(&self, method: Method, url: String) -> RequestBuilder {
+        self.request_with_xsrf_token(method, url, "no-check")
+    }
+
+    fn request_with_xsrf_token(
+        &self,
+        method: Method,
+        url: String,
+        xsrf_token: &str,
+    ) -> RequestBuilder {
+        self.client
+            .request(method, url)
+            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
+            .header("Accept", "application/json")
+            .header("X-Atlassian-Token", xsrf_token)
+    }
+
+    /// Send a request, retrying rate limited (429) and transient failures.
+    fn send(&self, builder: RequestBuilder) -> Result {
+        if builder.try_clone().is_none() {
+            // Streaming bodies can't be replayed, so there's nothing to retry with.
+            return Ok(builder.send()?);
+        }
+
+        self.send_retrying(|| {
+            builder
+                .try_clone()
+                .context("Request body cannot be replayed")
+        })
+    }
+
+    /// Send a request built afresh on every attempt, so that requests with a non replayable body
+    /// (attachment uploads) can be retried too.
+    fn send_retrying<F>(&self, build_request: F) -> Result
+    where
+        F: Fn() -> anyhow::Result<RequestBuilder>,
+    {
+        let mut attempt: u32 = 0;
+        loop {
+            let request = build_request()?.build()?;
+            let method = request.method().clone();
+            let path = String::from(request.url().path());
+
+            let result = self.client.execute(request);
+
+            let reason = match &result {
+                Ok(response) => classify_status(response.status(), &method),
+                Err(err) => classify_error(err, &method),
+            };
+
+            let Some(reason) = reason else {
+                return Ok(result?);
+            };
+
+            if attempt >= self.retry.max_retries {
+                print_error(&format!(
+                    "{} {}: {}. Giving up after {} attempts.",
+                    method,
+                    path,
+                    reason,
+                    attempt + 1
+                ));
+                return Ok(result?);
+            }
+
+            let delay = self.retry.delay_for(
+                attempt,
+                result.as_ref().ok().and_then(|r| retry_after(r.headers())),
+            );
+            attempt += 1;
+
+            print_warning(&format!(
+                "{} {}: {}. Retrying in {:.1}s ({}/{}).",
+                method,
+                path,
+                reason,
+                delay.as_secs_f64(),
+                attempt,
+                self.retry.max_retries
+            ));
+
+            sleep(delay);
+        }
     }
 
     pub fn get_space_by_key(&self, space_key: &str) -> Result {
-        let url = format!("https://{}/wiki/api/v2/spaces", self.hostname);
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .query(&[("keys", space_key)])
-            .send()
+        self.send(
+            self.request(Method::GET, self.rest_api_v2("spaces"))
+                .query(&[("keys", space_key)]),
+        )
     }
 
     pub fn create_page(&self, body_json: Value) -> Result {
-        let url = format!("https://{}/wiki/api/v2/pages", self.hostname);
-        self.client
-            .post(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .json(&body_json)
-            .send()
+        self.send(
+            self.request(Method::POST, self.rest_api_v2("pages"))
+                .json(&body_json),
+        )
     }
 
     pub(crate) fn create_folder(&self, body_json: Value) -> Result {
-        let url = self.rest_api_v2("folders");
-        self.client
-            .post(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .json(&body_json)
-            .send()
+        self.send(
+            self.request(Method::POST, self.rest_api_v2("folders"))
+                .json(&body_json),
+        )
     }
 
     pub fn get(&self, url: &reqwest::Url) -> Result {
-        self.client
-            .get(url.clone())
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .send()
+        self.send(self.request(Method::GET, url.to_string()))
     }
 
     pub fn get_all_pages_in_space(&self, space_id: &str) -> Result {
-        let url = format!(
-            "https://{}/wiki/api/v2/spaces/{}/pages",
-            self.hostname, space_id
-        );
-
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .send()
+        self.send(self.request(
+            Method::GET,
+            self.rest_api_v2(&format!("spaces/{}/pages", space_id)),
+        ))
     }
 
     pub fn get_all_pages_from_homepage(&self, homepage_id: &str) -> Result {
-        let url = self.rest_api_v2(&format!("pages/{}/descendants", homepage_id));
-
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .query(&[("limit", "1")])
-            .header("Accept", "application/json")
-            .send()
+        self.send(
+            self.request(
+                Method::GET,
+                self.rest_api_v2(&format!("pages/{}/descendants", homepage_id)),
+            )
+            .query(&[("limit", "1")]),
+        )
     }
 
     pub(crate) fn get_folder_descendants(&self, page_id: String) -> Result {
-        let url = self.rest_api_v2(&format!("folders/{}/descendants", page_id));
-
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .query(&[("depth", "1")])
-            .header("Accept", "application/json")
-            .send()
+        self.send(
+            self.request(
+                Method::GET,
+                self.rest_api_v2(&format!("folders/{}/descendants", page_id)),
+            )
+            .query(&[("depth", "1")]),
+        )
     }
 
     pub(crate) fn get_page_descendants(&self, page_id: String) -> Result {
-        let url = self.rest_api_v2(&format!("pages/{}/descendants", page_id));
-
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .query(&[("depth", "1")])
-            .header("Accept", "application/json")
-            .send()
+        self.send(
+            self.request(
+                Method::GET,
+                self.rest_api_v2(&format!("pages/{}/descendants", page_id)),
+            )
+            .query(&[("depth", "1")]),
+        )
     }
 
     pub fn update_page(&self, page_id: &String, payload: Value) -> Result {
-        let url = format!("https://{}/wiki/api/v2/pages/{}", self.hostname, page_id);
-        // let url = format!("https://{}/wiki/api/content/{}", self.hostname, page_id);
-        self.client
-            .put(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .json(&payload)
-            .send()
+        self.send(
+            self.request(Method::PUT, self.rest_api_v2(&format!("pages/{}", page_id)))
+                .json(&payload),
+        )
     }
 
     pub fn create_or_update_attachment(
         &self,
         content_id: &str,
-        file_part: Part,
-        hash: &String,
+        file: &Path,
+        file_name: &str,
+        hash: &str,
     ) -> Result {
-        let url = format!(
-            "https://{}/wiki/rest/api/content/{}/child/attachment",
-            self.hostname, content_id
-        );
-        let form = Form::new()
-            .text("minorEdit", "true")
-            .text("comment", format!("hash:{}", hash))
-            .part("file", file_part);
+        let url = self.rest_api(&format!("content/{}/child/attachment", content_id));
 
-        self.client
-            .put(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "nocheck")
-            .multipart(form)
-            .send()
+        // The form is rebuilt on every attempt because the file is streamed, and a streamed body
+        // can only be sent once.
+        self.send_retrying(|| {
+            let file_part = Part::file(file)
+                .with_context(|| format!("Opening {}", file.display()))?
+                .file_name(String::from(file_name));
+            let form = Form::new()
+                .text("minorEdit", "true")
+                .text("comment", format!("hash:{}", hash))
+                .part("file", file_part);
+
+            Ok(self
+                .request_with_xsrf_token(Method::PUT, url.clone(), "nocheck")
+                .multipart(form))
+        })
     }
 
     pub fn get_attachments(&self, page_id: &str) -> Result {
-        let url = format!(
-            "https://{}/wiki/api/v2/pages/{}/attachments",
-            self.hostname, page_id
-        );
-
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .send()
+        self.send(self.request(
+            Method::GET,
+            self.rest_api_v2(&format!("pages/{}/attachments", page_id)),
+        ))
     }
 
     pub(crate) fn remove_attachment(&self, id: &str) -> Result {
-        let url = format!("https://{}/wiki/api/v2/attachments/{}", self.hostname, id);
-
-        self.client
-            .delete(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .send()
+        self.send(self.request(
+            Method::DELETE,
+            self.rest_api_v2(&format!("attachments/{}", id)),
+        ))
     }
 
     pub(crate) fn get_page_labels(&self, page_id: &str) -> Result {
-        let url = format!(
-            "https://{}/wiki/rest/api/content/{}/label",
-            self.hostname, page_id
-        );
-
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(self.request(
+            Method::GET,
+            self.rest_api(&format!("content/{}/label", page_id)),
+        ))
     }
 
     pub(crate) fn set_page_labels(&self, page_id: &str, body: Vec<Value>) -> Result {
-        let url = format!(
-            "https://{}/wiki/rest/api/content/{}/label",
-            self.hostname, page_id
-        );
-
-        self.client
-            .post(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .json(&body)
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(
+            self.request(
+                Method::POST,
+                self.rest_api(&format!("content/{}/label", page_id)),
+            )
+            .json(&body),
+        )
     }
 
     pub(crate) fn remove_label(&self, page_id: &str, label: &crate::responses::Label) -> Result {
-        let url = format!(
-            "https://{}/wiki/rest/api/content/{}/label",
-            self.hostname, page_id
-        );
-
-        self.client
-            .delete(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .query(&[("name", label.name.clone())])
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(
+            self.request(
+                Method::DELETE,
+                self.rest_api(&format!("content/{}/label", page_id)),
+            )
+            .query(&[("name", label.name.clone())]),
+        )
     }
 
     pub(crate) fn get_properties(&self, page_id: &str) -> Result {
-        let url = format!(
-            "https://{}/wiki/api/v2/pages/{}/properties",
-            self.hostname, page_id
-        );
-
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(self.request(
+            Method::GET,
+            self.rest_api_v2(&format!("pages/{}/properties", page_id)),
+        ))
     }
 
     pub(crate) fn create_property(&self, page_id: &str, value: Value) -> Result {
-        let url = format!(
-            "https://{}/wiki/api/v2/pages/{}/properties",
-            self.hostname, page_id
-        );
-
-        self.client
-            .post(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .json(&value)
-            .send()
+        self.send(
+            self.request(
+                Method::POST,
+                self.rest_api_v2(&format!("pages/{}/properties", page_id)),
+            )
+            .json(&value),
+        )
     }
 
     pub(crate) fn set_property(&self, page_id: &str, property_id: &str, value: Value) -> Result {
-        let url = format!(
-            "https://{}/wiki/api/v2/pages/{}/properties/{}",
-            self.hostname, page_id, property_id
-        );
-
-        self.client
-            .put(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .json(&value)
-            .send()
+        self.send(
+            self.request(
+                Method::PUT,
+                self.rest_api_v2(&format!("pages/{}/properties/{}", page_id, property_id)),
+            )
+            .json(&value),
+        )
     }
 
     pub(crate) fn delete_property(&self, page_id: &str, property_id: &str) -> Result {
-        let url = format!(
-            "https://{}/wiki/api/v2/pages/{}/properties/{}",
-            self.hostname, page_id, property_id
-        );
-
-        self.client
-            .delete(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(self.request(
+            Method::DELETE,
+            self.rest_api_v2(&format!("pages/{}/properties/{}", page_id, property_id)),
+        ))
     }
 
     pub(crate) fn search_users(&self, public_name: &str) -> Result {
-        let url = self.rest_api("search/user");
-        self.client
-            .get(url)
-            .query(&[("cql", format!("user.fullname~\"{}\"", public_name))])
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(
+            self.request(Method::GET, self.rest_api("search/user"))
+                .query(&[("cql", format!("user.fullname~\"{}\"", public_name))]),
+        )
     }
 
     pub(crate) fn archive_page(&self, id: &str, note: &str) -> Result {
-        let url = self.graphql_api();
-        self.client
-            .post(url)
-            .query(&[("q", "ArchivePagesMutation")])
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .json(&json!({
-                "operationName": "ArchivePagesMutation",
-                "variables": {
-                    "input": [
-                        { "pageID": id, "archiveNote": note, "descendantsNoteApplicationOption": "NONE", "areChildrenIncluded": false}
-                    ]
-                },
-                "query": "mutation ArchivePagesMutation($input: [BulkArchivePagesInput]!) {\narchivePages(input: $input) {\n    taskId\n    status\n    __typename\n  }\n}\n"
-            }))
-            .send()
+        self.send(
+            self.request(Method::POST, self.graphql_api())
+                .query(&[("q", "ArchivePagesMutation")])
+                .json(&json!({
+                    "operationName": "ArchivePagesMutation",
+                    "variables": {
+                        "input": [
+                            { "pageID": id, "archiveNote": note, "descendantsNoteApplicationOption": "NONE", "areChildrenIncluded": false}
+                        ]
+                    },
+                    "query": "mutation ArchivePagesMutation($input: [BulkArchivePagesInput]!) {\narchivePages(input: $input) {\n    taskId\n    status\n    __typename\n  }\n}\n"
+                })),
+        )
     }
 
     pub(crate) fn unarchive_page(&self, id: &str) -> Result {
-        let url = self.graphql_api();
-        self.client
-            .post(url)
-            .query(&[("q", "ArchivePagesMutation")])
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .json(&json!({
-                "operationName": "UnarchivePagesMutation",
-                "variables": {
-                    "pageIDs": [ id ],
-                    "includeChildren": false
-                },
-                "query": "mutation UnarchivePagesMutation($pageIDs: [Long!]!, $includeChildren: [Boolean!]!, $parentPageId: Long) {\n  bulkUnarchivePages(\n    pageIDs: $pageIDs\n    includeChildren: $includeChildren\n    parentPageId: $parentPageId\n  ) {\n    taskId\n    status\n    __typename\n  }\n}\n"
-            }))
-            .send()
+        self.send(
+            self.request(Method::POST, self.graphql_api())
+                .query(&[("q", "ArchivePagesMutation")])
+                .json(&json!({
+                    "operationName": "UnarchivePagesMutation",
+                    "variables": {
+                        "pageIDs": [ id ],
+                        "includeChildren": false
+                    },
+                    "query": "mutation UnarchivePagesMutation($pageIDs: [Long!]!, $includeChildren: [Boolean!]!, $parentPageId: Long) {\n  bulkUnarchivePages(\n    pageIDs: $pageIDs\n    includeChildren: $includeChildren\n    parentPageId: $parentPageId\n  ) {\n    taskId\n    status\n    __typename\n  }\n}\n"
+                })),
+        )
     }
 
     pub(crate) fn move_page(&self, page_id: &str, parent_id: &str) -> Result {
-        let url = self.graphql_api();
-        self.client
-            .post(url)
-            .query(&[("q", "useMovePageHandlerMovePageAppendMutation")])
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .json(&json!({
+        self.send(
+            self.request(Method::POST, self.graphql_api())
+                .query(&[("q", "useMovePageHandlerMovePageAppendMutation")])
+                .json(&json!({
                     "operationName": "useMovePageHandlerMovePageAppendMutation",
                     "variables": {
                         "pageId": page_id,
                         "parentId": parent_id,
                     },
                     "query": "mutation useMovePageHandlerMovePageAppendMutation($pageId: ID!, $parentId: ID!) {\n  movePageAppend(input: {pageId: $pageId, parentId: $parentId}) {\n    page {\n      id\n      links {\n        webui\n        editui\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n"
-                }))
-            .send()
+                })),
+        )
     }
 
     pub(crate) fn set_restrictions(&self, id: &str, body: Value) -> Result {
-        let url = self.rest_api(&format!("content/{}/restriction", id));
-        self.client
-            .put(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .json(&body)
-            .send()
+        self.send(
+            self.request(
+                Method::PUT,
+                self.rest_api(&format!("content/{}/restriction", id)),
+            )
+            .json(&body),
+        )
     }
 
     pub(crate) fn current_user(&self) -> Result {
-        let url = self.rest_api("user/current");
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(self.request(Method::GET, self.rest_api("user/current")))
     }
 
     pub(crate) fn delete_restrictions(&self, id: &str) -> Result {
-        let url = self.rest_api(&format!("content/{}/restriction", id));
-        self.client
-            .delete(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(self.request(
+            Method::DELETE,
+            self.rest_api(&format!("content/{}/restriction", id)),
+        ))
     }
 
     pub(crate) fn get_restrictions_by_operation(&self, id: &str) -> Result {
-        let url = self.rest_api(&format!("content/{}/restriction/byOperation", id));
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(self.request(
+            Method::GET,
+            self.rest_api(&format!("content/{}/restriction/byOperation", id)),
+        ))
     }
 
     pub(crate) fn move_page_relative(
@@ -421,58 +434,236 @@ impl ConfluenceClient {
         position: &str,
         target_id: &str,
     ) -> Result {
-        let url = self.rest_api(&format!(
-            "content/{}/move/{}/{}",
-            page_id, position, target_id
-        ));
-        self.client
-            .put(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(self.request(
+            Method::PUT,
+            self.rest_api(&format!(
+                "content/{}/move/{}/{}",
+                page_id, position, target_id
+            )),
+        ))
     }
 
     pub(crate) fn get_space_suggested_content_states(&self, space_key: &str) -> Result {
-        let url = self.rest_api(&format!("space/{}/state", space_key));
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(self.request(
+            Method::GET,
+            self.rest_api(&format!("space/{}/state", space_key)),
+        ))
     }
 
     pub(crate) fn set_content_state(&self, id: &str, status: &str, body: Value) -> Result {
-        let url = self.rest_api(&format!("content/{}/state", id));
-        self.client
-            .put(url)
-            .query(&[("status", status)])
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .json(&body)
-            .send()
+        self.send(
+            self.request(Method::PUT, self.rest_api(&format!("content/{}/state", id)))
+                .query(&[("status", status)])
+                .json(&body),
+        )
     }
 
     pub(crate) fn get_content_state(&self, id: &str) -> Result {
-        let url = self.rest_api(&format!("content/{}/state", id));
-        self.client
-            .get(url)
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(self.request(Method::GET, self.rest_api(&format!("content/{}/state", id))))
     }
 
     pub(crate) fn remove_content_state(&self, id: &str, status: &str) -> Result {
-        let url = self.rest_api(&format!("content/{}/state", id));
-        self.client
-            .delete(url)
-            .query(&[("status", status)])
-            .basic_auth(self.api_user.clone(), Some(self.api_token.clone()))
-            .header("Accept", "application/json")
-            .header("X-Atlassian-Token", "no-check")
-            .send()
+        self.send(
+            self.request(
+                Method::DELETE,
+                self.rest_api(&format!("content/{}/state", id)),
+            )
+            .query(&[("status", status)]),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use assert_fs::fixture::{FileWriteStr, PathChild};
+    use mockito::Matcher;
+    use serde_json::json;
+
+    use crate::error::TestResult;
+
+    use super::*;
+
+    fn page_body() -> String {
+        json!({ "id": "1", "title": "A Page" }).to_string()
+    }
+
+    #[test]
+    fn it_retries_rate_limited_requests() -> TestResult {
+        let mut server = mockito::Server::new();
+        let client = ConfluenceClient::new_insecure(&server.host_with_port());
+
+        let rate_limited = server
+            .mock("GET", "/wiki/api/v2/spaces")
+            .match_query(Matcher::Any)
+            .with_status(429)
+            .with_header("retry-after", "0")
+            .with_body("Rate limit exceeded")
+            .expect(2)
+            .create();
+
+        let ok = server
+            .mock("GET", "/wiki/api/v2/spaces")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_body(json!({ "results": [] }).to_string())
+            .create();
+
+        let response = client.get_space_by_key("TEST")?;
+
+        assert_eq!(response.status(), 200);
+        rate_limited.assert();
+        ok.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_gives_up_after_the_configured_number_of_retries() -> TestResult {
+        let mut server = mockito::Server::new();
+        let client = ConfluenceClient::new_insecure(&server.host_with_port()).with_retry_config(
+            RetryConfig {
+                max_retries: 2,
+                initial_backoff: Duration::from_millis(1),
+                max_backoff: Duration::from_millis(5),
+            },
+        );
+
+        // The initial attempt plus two retries.
+        let rate_limited = server
+            .mock("GET", "/wiki/api/v2/spaces")
+            .match_query(Matcher::Any)
+            .with_status(429)
+            .expect(3)
+            .create();
+
+        let response = client.get_space_by_key("TEST")?;
+
+        assert_eq!(response.status(), 429);
+        rate_limited.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_retries_rate_limited_writes() -> TestResult {
+        let mut server = mockito::Server::new();
+        let client = ConfluenceClient::new_insecure(&server.host_with_port());
+
+        let rate_limited = server
+            .mock("POST", "/wiki/api/v2/pages")
+            .with_status(429)
+            .expect(1)
+            .create();
+
+        let created = server
+            .mock("POST", "/wiki/api/v2/pages")
+            .with_status(200)
+            .with_body(page_body())
+            .create();
+
+        let response = client.create_page(json!({"title": "A Page"}))?;
+
+        assert_eq!(response.status(), 200);
+        rate_limited.assert();
+        created.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_retries_rate_limited_attachment_uploads() -> TestResult {
+        let mut server = mockito::Server::new();
+        let client = ConfluenceClient::new_insecure(&server.host_with_port());
+
+        let temp = assert_fs::TempDir::new()?;
+        let attachment = temp.child("image.png");
+        attachment.write_str("not really a png")?;
+
+        let rate_limited = server
+            .mock("PUT", "/wiki/rest/api/content/1/child/attachment")
+            .with_status(429)
+            .expect(1)
+            .create();
+
+        let uploaded = server
+            .mock("PUT", "/wiki/rest/api/content/1/child/attachment")
+            .with_status(200)
+            .with_body(json!({ "results": [] }).to_string())
+            .create();
+
+        let response =
+            client.create_or_update_attachment("1", attachment.path(), "image.png", "hash")?;
+
+        assert_eq!(response.status(), 200);
+        rate_limited.assert();
+        uploaded.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_retries_transient_server_errors_on_reads() -> TestResult {
+        let mut server = mockito::Server::new();
+        let client = ConfluenceClient::new_insecure(&server.host_with_port());
+
+        let unavailable = server
+            .mock("GET", "/wiki/api/v2/pages/1/properties")
+            .with_status(503)
+            .expect(1)
+            .create();
+
+        let ok = server
+            .mock("GET", "/wiki/api/v2/pages/1/properties")
+            .with_status(200)
+            .with_body(json!({ "results": [] }).to_string())
+            .create();
+
+        let response = client.get_properties("1")?;
+
+        assert_eq!(response.status(), 200);
+        unavailable.assert();
+        ok.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_does_not_retry_server_errors_on_creates() -> TestResult {
+        let mut server = mockito::Server::new();
+        let client = ConfluenceClient::new_insecure(&server.host_with_port());
+
+        // Repeating a failed create could duplicate the page, so it must be attempted once only.
+        let failed = server
+            .mock("POST", "/wiki/api/v2/pages")
+            .with_status(500)
+            .expect(1)
+            .create();
+
+        let response = client.create_page(json!({"title": "A Page"}))?;
+
+        assert_eq!(response.status(), 500);
+        failed.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_does_not_retry_client_errors() -> TestResult {
+        let mut server = mockito::Server::new();
+        let client = ConfluenceClient::new_insecure(&server.host_with_port());
+
+        let unauthorized = server
+            .mock("GET", "/wiki/api/v2/spaces")
+            .match_query(Matcher::Any)
+            .with_status(401)
+            .expect(1)
+            .create();
+
+        let response = client.get_space_by_key("TEST")?;
+
+        assert_eq!(response.status(), 401);
+        unauthorized.assert();
+
+        Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,13 +42,11 @@ impl ConfluenceError {
             StatusCode::UNAUTHORIZED => {
                 String::from("Unauthorized. Check your API_USER/API_TOKEN and try again.")
             }
-            _ => {
-                let json: serde_json::Value = match response.json() {
-                    Ok(j) => j,
-                    Err(_) => todo!(),
-                };
-                json["errors"][0].to_string()
-            }
+            StatusCode::TOO_MANY_REQUESTS => String::from(
+                "Rate limited by Confluence. Retries were exhausted: \
+                 slow the sync down or allow more retries with $MARKED_SPACE_MAX_RETRIES.",
+            ),
+            _ => describe_error_body(response),
         };
         ConfluenceError::FailedRequest {
             status,
@@ -64,6 +62,33 @@ impl ConfluenceError {
             errors,
         }
         .into()
+    }
+}
+
+/// Describe the body of a failed response. Confluence answers with JSON for most errors, but
+/// gateway and rate limiting responses are often HTML or plain text, so fall back to the raw body.
+fn describe_error_body(response: Response) -> String {
+    const MAX_BODY_LENGTH: usize = 512;
+
+    let body = match response.text() {
+        Ok(body) => body,
+        Err(err) => return format!("could not read response body: {}", err),
+    };
+
+    match serde_json::from_str::<serde_json::Value>(&body) {
+        Ok(json) if !json["errors"][0].is_null() => json["errors"][0].to_string(),
+        Ok(json) if !json["message"].is_null() => json["message"].to_string(),
+        _ => {
+            let body = body.trim();
+            if body.len() > MAX_BODY_LENGTH {
+                format!(
+                    "{}...",
+                    body.chars().take(MAX_BODY_LENGTH).collect::<String>()
+                )
+            } else {
+                String::from(body)
+            }
+        }
     }
 }
 

--- a/src/link_generator.rs
+++ b/src/link_generator.rs
@@ -2,7 +2,7 @@ use path_clean::PathClean;
 use std::{
     collections::{HashMap, HashSet},
     io::{self, Write},
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use comrak::nodes::NodeLink;
@@ -141,7 +141,7 @@ impl LinkGenerator {
     }
 
     fn get_page_url(&self, filename: &Path) -> Option<String> {
-        if filename == PathBuf::from("index.md") {
+        if filename == Path::new("index.md") {
             return Some(self.id_to_url(&self.homepage_id));
         }
         if let Ok(s) = Self::path_to_string(filename) {
@@ -191,8 +191,8 @@ impl LinkGenerator {
             if link_empty {
                 print_warning(&format!(
                     "file link {} in {} couldn't be resolved",
-                    &local_link.text,
-                    &confluence_formatter.source.display(),
+                    local_link.text,
+                    confluence_formatter.source.display(),
                 ));
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod page_statuses;
 mod parent;
 mod responses;
 mod restrictions;
+mod retry;
 mod sort;
 mod sync;
 mod sync_operation;
@@ -45,6 +46,7 @@ mod template_renderer;
 mod test_helpers;
 
 use crate::error::{ConfluenceError, Result};
+use crate::retry::RetryConfig;
 use crate::sync::sync_space;
 
 fn check_environment_vars() -> Result<()> {
@@ -82,6 +84,11 @@ pub struct Args {
     /// space editable to anyone who has access to the space.
     #[arg(long)]
     check: bool,
+
+    /// How many times to retry a request that was rate limited (429) or failed transiently.
+    /// Can also be specified in $MARKED_SPACE_MAX_RETRIES.
+    #[arg(long)]
+    max_retries: Option<u32>,
 }
 
 fn main() -> Result<ExitCode> {
@@ -102,7 +109,11 @@ fn main() -> Result<ExitCode> {
             return Ok(ExitCode::FAILURE);
         }
     };
-    let confluence_client = ConfluenceClient::new(host.as_str());
+    let mut retry_config = RetryConfig::from_env();
+    if let Some(max_retries) = args.max_retries {
+        retry_config.max_retries = max_retries;
+    }
+    let confluence_client = ConfluenceClient::new(host.as_str()).with_retry_config(retry_config);
 
     match sync_space(confluence_client, &mut markdown_space, args) {
         Ok(_) => Ok(ExitCode::SUCCESS),

--- a/src/markdown_page.rs
+++ b/src/markdown_page.rs
@@ -152,19 +152,16 @@ impl<'a> MarkdownPage<'a> {
                     ));
                 }
             }
-            NodeValue::Link(node_link) => {
-                if LocalLink::is_local_link(&node_link.url) {
-                    if let Ok(local_link) = LocalLink::from_str(&node_link.url, markdown_page) {
-                        if local_link.is_page() {
-                            local_links.push(local_link);
-                        } else {
-                            attachments.push(Attachment::file(local_link));
-                        }
+            // remote links are left alone
+            NodeValue::Link(node_link) if LocalLink::is_local_link(&node_link.url) => {
+                if let Ok(local_link) = LocalLink::from_str(&node_link.url, markdown_page) {
+                    if local_link.is_page() {
+                        local_links.push(local_link);
                     } else {
-                        errors.push(format!("Failed to parse local link: {}", node_link.url));
+                        attachments.push(Attachment::file(local_link));
                     }
                 } else {
-                    // remote link
+                    errors.push(format!("Failed to parse local link: {}", node_link.url));
                 }
             }
             _ => (),

--- a/src/markdown_space.rs
+++ b/src/markdown_space.rs
@@ -211,7 +211,7 @@ impl<'a> MarkdownSpace<'a> {
             return Err(ConfluenceError::generic_error(format!(
                 "{} Error(s) parsing space:\n  {}",
                 parse_errors.len(),
-                &error_string
+                error_string
             )));
         }
 

--- a/src/page_emojis.rs
+++ b/src/page_emojis.rs
@@ -10,7 +10,7 @@ pub(crate) fn parse_emoji(page: &MarkdownPage) -> Option<String> {
             emoji.as_str().chars().next().unwrap() as u32
         ))
     } else {
-        print_warning(&format!("Unknown short code '{}'", &emoji_string));
+        print_warning(&format!("Unknown short code '{}'", emoji_string));
         None
     }
 }

--- a/src/page_properties.rs
+++ b/src/page_properties.rs
@@ -91,13 +91,13 @@ pub fn sync_page_properties(
         let update_response = if property_update.value.is_null() {
             print_status(
                 Status::Deleted,
-                &format!("property {}", &property_update.key),
+                &format!("property {}", property_update.key),
             );
             confluence_client.delete_property(page_id, &property_update.id)
         } else if property_update.id.is_empty() {
             print_status(
                 Status::Created,
-                &format!("property {}", &property_update.key),
+                &format!("property {}", property_update.key),
             );
             confluence_client.create_property(
                 page_id,
@@ -106,7 +106,7 @@ pub fn sync_page_properties(
         } else {
             print_status(
                 Status::Updated,
-                &format!("property {}", &property_update.key),
+                &format!("property {}", property_update.key),
             );
             confluence_client.set_property(
                 page_id,

--- a/src/restrictions.rs
+++ b/src/restrictions.rs
@@ -80,7 +80,7 @@ pub fn sync_restrictions(
     };
     if let Some(response) = updated {
         if !response.status().is_success() {
-            println!("{}", &response.text()?);
+            println!("{}", response.text()?);
             return Err(anyhow::anyhow!("Not able to update restrictions"));
         }
     }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,304 @@
+//! Retry policy for requests to Confluence.
+//!
+//! Confluence Cloud rate limits aggressively and answers with `429 Too Many Requests` (usually
+//! with a `Retry-After` header) when a sync makes requests faster than the allowance. It also
+//! occasionally returns transient 5xx errors. Both are retried with an exponential backoff.
+
+use std::env;
+use std::fmt;
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+use reqwest::{Method, StatusCode};
+
+pub const MAX_RETRIES_ENV: &str = "MARKED_SPACE_MAX_RETRIES";
+pub const INITIAL_BACKOFF_MS_ENV: &str = "MARKED_SPACE_RETRY_INITIAL_BACKOFF_MS";
+pub const MAX_BACKOFF_SECS_ENV: &str = "MARKED_SPACE_RETRY_MAX_BACKOFF_SECS";
+
+const DEFAULT_MAX_RETRIES: u32 = 8;
+const DEFAULT_INITIAL_BACKOFF_MS: u64 = 500;
+const DEFAULT_MAX_BACKOFF_SECS: u64 = 60;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetryConfig {
+    /// Number of retries *after* the initial attempt. Zero disables retrying.
+    pub max_retries: u32,
+    /// Backoff before the first retry. Doubles on every subsequent retry.
+    pub initial_backoff: Duration,
+    /// Upper bound for any single wait, including waits requested by `Retry-After`.
+    pub max_backoff: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        RetryConfig {
+            max_retries: DEFAULT_MAX_RETRIES,
+            initial_backoff: Duration::from_millis(DEFAULT_INITIAL_BACKOFF_MS),
+            max_backoff: Duration::from_secs(DEFAULT_MAX_BACKOFF_SECS),
+        }
+    }
+}
+
+impl RetryConfig {
+    pub fn from_env() -> Self {
+        let defaults = RetryConfig::default();
+        RetryConfig {
+            max_retries: env_parsed(MAX_RETRIES_ENV).unwrap_or(defaults.max_retries),
+            initial_backoff: env_parsed(INITIAL_BACKOFF_MS_ENV)
+                .map(Duration::from_millis)
+                .unwrap_or(defaults.initial_backoff),
+            max_backoff: env_parsed(MAX_BACKOFF_SECS_ENV)
+                .map(Duration::from_secs)
+                .unwrap_or(defaults.max_backoff),
+        }
+    }
+
+    /// Wait before the retry following `attempt` (zero based), preferring the delay the server
+    /// asked for over our own exponential backoff. Never waits longer than `max_backoff`, so a
+    /// server asking us to come back in an hour still gets retried (and, if it's still rate
+    /// limiting us, asked again) within a sensible time.
+    pub fn delay_for(&self, attempt: u32, server_suggested: Option<Duration>) -> Duration {
+        let delay = match server_suggested {
+            Some(suggested) => suggested,
+            None => self.backoff(attempt),
+        };
+        delay.min(self.max_backoff)
+    }
+
+    /// Exponential backoff with jitter: a random point in `[half, full]` of the current window,
+    /// so that repeated collisions with the rate limiter don't line up.
+    fn backoff(&self, attempt: u32) -> Duration {
+        let window = self
+            .initial_backoff
+            .saturating_mul(1u32.checked_shl(attempt).unwrap_or(u32::MAX))
+            .min(self.max_backoff);
+
+        window.mul_f64(jitter_fraction())
+    }
+}
+
+fn env_parsed<T: FromStr>(name: &str) -> Option<T> {
+    env::var(name).ok()?.trim().parse().ok()
+}
+
+/// A pseudo random fraction in `[0.5, 1.0)`. The clock is a good enough entropy source for
+/// spreading out retries, and saves pulling in a random number generator.
+fn jitter_fraction() -> f64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    0.5 + 0.5 * f64::from(nanos % 1_000_000) / 1_000_000.0
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RetryReason {
+    RateLimited,
+    ServerError(StatusCode),
+    Transport(String),
+}
+
+impl fmt::Display for RetryReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RetryReason::RateLimited => write!(f, "rate limited by Confluence (429)"),
+            RetryReason::ServerError(status) => write!(f, "server error ({})", status),
+            RetryReason::Transport(message) => write!(f, "{}", message),
+        }
+    }
+}
+
+/// Requests that can safely be repeated when we don't know whether the server processed them.
+/// A rate limited request is never processed, so 429s are retried whatever the method is; the
+/// remaining cases are only retried when repeating them can't create duplicates.
+fn is_idempotent(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::GET | Method::HEAD | Method::PUT | Method::DELETE | Method::OPTIONS | Method::TRACE
+    )
+}
+
+pub fn classify_status(status: StatusCode, method: &Method) -> Option<RetryReason> {
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        Some(RetryReason::RateLimited)
+    } else if status.is_server_error() && is_idempotent(method) {
+        Some(RetryReason::ServerError(status))
+    } else {
+        None
+    }
+}
+
+pub fn classify_error(err: &reqwest::Error, method: &Method) -> Option<RetryReason> {
+    // A connection that was never established can always be retried. Anything else may have
+    // reached the server, so only repeat it for idempotent methods.
+    let retryable =
+        err.is_connect() || (is_idempotent(method) && (err.is_timeout() || err.is_request()));
+
+    if retryable {
+        Some(RetryReason::Transport(err.to_string()))
+    } else {
+        None
+    }
+}
+
+/// The `Retry-After` delay in seconds. HTTP dates are valid in this header too, but Confluence
+/// Cloud sends seconds, and falling back to our own backoff for anything else is harmless.
+pub fn retry_after(headers: &HeaderMap) -> Option<Duration> {
+    let value = headers.get(RETRY_AFTER)?.to_str().ok()?;
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::error::TestResult;
+    use reqwest::header::HeaderValue;
+
+    fn headers_with_retry_after(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_str(value).unwrap());
+        headers
+    }
+
+    #[test]
+    fn it_parses_retry_after_seconds() -> TestResult {
+        let headers = headers_with_retry_after("12");
+
+        assert_eq!(retry_after(&headers), Some(Duration::from_secs(12)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_ignores_unparseable_retry_after() -> TestResult {
+        assert_eq!(retry_after(&HeaderMap::new()), None);
+        assert_eq!(
+            retry_after(&headers_with_retry_after("Wed, 21 Oct 2015 07:28:00 GMT")),
+            None
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_backs_off_exponentially_up_to_the_maximum() -> TestResult {
+        let config = RetryConfig {
+            max_retries: 10,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(10),
+        };
+
+        for (attempt, window) in [(0, 1), (1, 2), (2, 4), (3, 8), (4, 10), (30, 10)] {
+            let delay = config.delay_for(attempt, None);
+            let window = Duration::from_secs(window);
+            assert!(
+                delay >= window / 2 && delay <= window,
+                "attempt {} gave {:?}, expected within [{:?}, {:?}]",
+                attempt,
+                delay,
+                window / 2,
+                window
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_prefers_the_server_suggested_delay() -> TestResult {
+        let config = RetryConfig {
+            max_retries: 10,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(30),
+        };
+
+        assert_eq!(
+            config.delay_for(0, Some(Duration::from_secs(17))),
+            Duration::from_secs(17)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_caps_the_server_suggested_delay() -> TestResult {
+        let config = RetryConfig {
+            max_retries: 10,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(30),
+        };
+
+        assert_eq!(
+            config.delay_for(0, Some(Duration::from_secs(3600))),
+            Duration::from_secs(30)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_retries_rate_limits_for_any_method() -> TestResult {
+        for method in [Method::GET, Method::POST, Method::PUT, Method::DELETE] {
+            assert_eq!(
+                classify_status(StatusCode::TOO_MANY_REQUESTS, &method),
+                Some(RetryReason::RateLimited),
+                "{} should be retried when rate limited",
+                method
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_only_retries_server_errors_for_idempotent_methods() -> TestResult {
+        assert_eq!(
+            classify_status(StatusCode::SERVICE_UNAVAILABLE, &Method::GET),
+            Some(RetryReason::ServerError(StatusCode::SERVICE_UNAVAILABLE))
+        );
+        assert_eq!(
+            classify_status(StatusCode::SERVICE_UNAVAILABLE, &Method::POST),
+            None
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_does_not_retry_client_errors() -> TestResult {
+        assert_eq!(classify_status(StatusCode::NOT_FOUND, &Method::GET), None);
+        assert_eq!(
+            classify_status(StatusCode::UNAUTHORIZED, &Method::GET),
+            None
+        );
+        assert_eq!(classify_status(StatusCode::CONFLICT, &Method::PUT), None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_reads_config_from_env() -> TestResult {
+        // Note: env vars are process wide, so this test sets and restores them itself.
+        env::set_var(MAX_RETRIES_ENV, "3");
+        env::set_var(INITIAL_BACKOFF_MS_ENV, "50");
+        env::set_var(MAX_BACKOFF_SECS_ENV, "5");
+
+        let config = RetryConfig::from_env();
+
+        env::remove_var(MAX_RETRIES_ENV);
+        env::remove_var(INITIAL_BACKOFF_MS_ENV);
+        env::remove_var(MAX_BACKOFF_SECS_ENV);
+
+        assert_eq!(
+            config,
+            RetryConfig {
+                max_retries: 3,
+                initial_backoff: Duration::from_millis(50),
+                max_backoff: Duration::from_secs(5),
+            }
+        );
+
+        Ok(())
+    }
+}

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -279,7 +279,7 @@ mod test {
         assert!(
             is_sorted(&test_sorter.result),
             "Not sorted: {:?}",
-            &test_sorter.result
+            test_sorter.result
         );
 
         let expected = output_moves


### PR DESCRIPTION
Syncing a larger space runs into Confluence Cloud's rate limiter and the sync aborts on the first `429 Too Many Requests`. This makes the client retry instead.

## What changed

**A single retrying `send()`.** Every endpoint in `ConfluenceClient` previously built its own request and called `.send()` directly. They now go through a shared `request()`/`send()` pair, so retry behaviour is defined in exactly one place.

**Retry policy** (new `src/retry.rs`):

- `429` is retried for **every** method — a rate limited request was rejected, not processed, so repeating it can't duplicate anything.
- `5xx` responses and dropped connections are retried only for idempotent methods (GET/PUT/DELETE). A failed `POST /pages` is reported as before rather than blindly retried, so a create can't produce two pages.
- The wait is whatever `Retry-After` asks for, capped at `max_backoff`; without that header it's exponential backoff with jitter (500ms → 1s → 2s → 4s…, capped at 60s).
- Retries are reported as they happen, and giving up prints an explicit error:
  ```text
  warning: GET /wiki/api/v2/pages/12345/properties: rate limited by Confluence (429). Retrying in 2.0s (3/8).
  ```

**Attachment uploads.** These stream a multipart body, which can't be replayed, so the form is rebuilt per attempt. `create_or_update_attachment` now takes the file path and name rather than a prebuilt `Part`.

**Configuration.** `--max-retries`, plus `$MARKED_SPACE_MAX_RETRIES`, `$MARKED_SPACE_RETRY_INITIAL_BACKOFF_MS` and `$MARKED_SPACE_RETRY_MAX_BACKOFF_SECS`. Defaults (8 retries) documented in a new README section.

**Two fixes found on the way:**

- `ConfluenceError::failed_request()` contained a `todo!()` that panicked whenever an error body wasn't JSON — which is exactly what a rate limited or gateway response tends to be. It now falls back to the raw body (truncated), and gives a specific message for an exhausted 429.
- Several endpoints hard coded `https://` instead of using the `rest_api_v2()` helper, so they ignored the insecure flag used by tests. They now use the helpers; no change in production behaviour.

The client also gained connect (10s) and request (60s) timeouts — it previously had none, so a hung connection would hang the sync — and a `marked-space/<version>` user agent.

## Testing

`cargo test` — 150 pass, 16 of them new:

- retries a 429 and succeeds on a later attempt (reads, writes and attachment uploads)
- gives up after the configured number of retries and returns the 429 to the caller
- retries `503` on a GET but **not** on a `POST /pages`
- does not retry `401`/`404`/`409`
- `Retry-After` parsing, backoff bounds and jitter window, capping, and env config

`cargo fmt --all -- --check` is clean. `cargo clippy --all-targets` reports one pre-existing `cmp_owned` warning in `link_generator.rs` that this branch doesn't touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6bpksyMe8DQdqZvm6uGdz)_