### PR TITLE
Fix tag-release.sh leaving v1 and v1.0 behind

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,38 @@ cargo run -- --space example/team
 cargo watch -x test
 ```
 
+## Making a Release
+
+Releases are cut from `main` by tagging the version already in `Cargo.toml`:
+
+```bash
+git checkout main && git pull
+bash scripts/tag-release.sh
+```
+
+The script refuses to run off `main`, with a dirty working tree, or when local
+`main` differs from `origin/main`. It then pushes three tags:
+
+| Tag        | Purpose                                                        |
+| ---------- | -------------------------------------------------------------- |
+| `v1.2.3`   | New and immutable. Pushing it is what triggers the release.      |
+| `v1.2`     | Moved to the new release.                                        |
+| `v1`       | Moved to the new release. This is what `@v1` users get.          |
+
+Only the full `vX.Y.Z` tag matches the trigger in `rust-release.yml`, but the
+moving tags matter just as much: consumers pin to them (`uses:
+james-allan-lloyd/marked-space@v1`, and the image tag in `action.yml`), so a
+release that leaves them behind reaches nobody.
+
+Pushing the tag runs the tests, builds the Linux and Windows binaries, publishes
+the Docker image as `v1.2.3`, `v1.2` and `v1`, and then creates the GitHub
+release **as a draft**. The last step is manual: open the draft release, add the
+notes and publish it.
+
+Afterwards, bump `version` in `Cargo.toml` for the next cycle (the "Begin 1.2.4"
+commits). Creating the version tag fails if that version was already released,
+so a forgotten bump stops the release rather than moving an existing one.
+
 ## Rate Limiting and Retries
 
 Confluence Cloud rate limits its REST API, and a sync of a larger space can run

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,18 +1,44 @@
+#!/usr/bin/env bash
+# Tag the version in Cargo.toml as a release. Pushing v<major>.<minor>.<patch>
+# is what triggers .github/workflows/rust-release.yml.
 set -xe
 VERSION=$(grep -m 1 '^version' Cargo.toml | sed 's/^version = "\(.*\)"$/\1/')
 MAJOR=$(echo $VERSION | cut -d. -f1)
 MINOR=$(echo $VERSION | cut -d. -f2)
 PATCH=$(echo $VERSION | cut -d. -f3)
 
-# FORCE=-f
 if [[ $(git branch --show-current) != main ]]; then
   echo "Need to run on main branch"
   exit 1
 fi
 
+if [[ -n $(git status --porcelain) ]]; then
+  echo "Working tree is dirty: commit or stash before releasing"
+  exit 1
+fi
+
+# Tag what's on the remote, not a stale or unpushed local main.
+git fetch origin main
+if [[ $(git rev-parse HEAD) != $(git rev-parse FETCH_HEAD) ]]; then
+  echo "main is not in sync with origin/main: pull (or push) before releasing"
+  exit 1
+fi
+
 echo $VERSION
-git tag $FORCE v$VERSION
-git tag -f v$MAJOR.$MINOR # these are always forced
+
+# The version tag is immutable, so this fails if $VERSION was already released.
+# That's the reminder to bump the version in Cargo.toml first.
+git tag v$VERSION
+
+# The major and minor tags always move to the release being cut: consumers pin
+# to them (uses: james-allan-lloyd/marked-space@v1, and the image tag in
+# action.yml), so a release that leaves them behind reaches nobody.
+git tag -f v$MAJOR.$MINOR
 git tag -f v$MAJOR
 
-git push origin v$VERSION v$MAJOR.$MINOR v$MAJOR $FORCE
+# Pushed separately, and only the moving tags are forced. Without --force the
+# remote rejects them for already existing, while v$VERSION goes through on its
+# own: the release then builds and publishes, but every consumer pinned to v1
+# stays on the previous version.
+git push origin v$VERSION
+git push origin --force v$MAJOR.$MINOR v$MAJOR


### PR DESCRIPTION
Cutting a release with `scripts/tag-release.sh` currently ships the version but leaves every consumer on the previous one.

## The bug

The script force-moves the major and minor tags locally, then pushes all three together without `--force`:

```bash
git tag $FORCE v$VERSION
git tag -f v$MAJOR.$MINOR      # "these are always forced"
git tag -f v$MAJOR
git push origin v$VERSION v$MAJOR.$MINOR v$MAJOR $FORCE
```

`$FORCE` is empty — the `FORCE=-f` line is commented out — so the push comes back:

```
 * [new tag]         v1.0.5 -> v1.0.5
 ! [rejected]        v1 -> v1 (already exists)
 ! [rejected]        v1.0 -> v1.0 (already exists)
error: failed to push some refs
```

Pushes are not atomic, so this is a partial success, which is the awkward part:

- `v1.0.5` lands, so the release workflow runs, binaries are built and the Docker image is published
- `v1` and `v1.0` stay on the previous release
- the script exits non-zero, so it reads as "the release failed" even though it partly happened

Anything pinned to the moving tags keeps getting the old version — including this repo's own `action.yml`, which runs `docker://jamesallanlloyd/marked-space:v1`, and any user on `uses: james-allan-lloyd/marked-space@v1`.

## The fix

Push the version tag on its own, then force only the moving tags:

```bash
git push origin v$VERSION
git push origin --force v$MAJOR.$MINOR v$MAJOR
```

Uncommenting `FORCE=-f` would also have made the push succeed, but it applies to `git tag $FORCE v$VERSION` as well — making the one tag that should be immutable silently overwritable. Left strict, `git tag v$VERSION` fails when the version was already released, which is the reminder to bump `Cargo.toml`.

Two guards added while here, both aimed at not tagging the wrong commit:

- refuse a dirty working tree
- refuse when local `main` differs from `origin/main` (fetched and compared, so an unpushed or stale `main` can't be released)

## Documentation

New "Making a Release" section in the README: the commands, what each of the three tags is for, what the tag push triggers, that the GitHub release is created **as a draft** and has to be published by hand, and the `Cargo.toml` bump for the next cycle.

## Testing

No unit tests to hang this off, so it was verified against a scratch repo reproducing the current tag layout (`v1.0.4`, `v1.0`, `v1` all on one commit, `Cargo.toml` at `1.0.5`):

| Case | Result |
| --- | --- |
| Old script | `v1.0.5` pushed, `v1`/`v1.0` rejected and left on the old commit |
| New script | all three tags on the new commit |
| Re-run without bumping the version | `fatal: tag 'v1.0.5' already exists`, remote untouched |
| Unpushed commit on `main` | refused, remote untouched |
| Run off `main` | refused, remote untouched |

`bash -n` clean. No Rust code is touched, so the build is unaffected.