### PR TITLE
Support mailto: links

### DIFF
--- a/example/team/formatting.md
+++ b/example/team/formatting.md
@@ -78,6 +78,9 @@ And a link to a section in this page: [Code](#Code)
 
 And a link to a section in another page: [Sub page section](subpages/subpage1.md#Sub-Page-Section)
 
+Email addresses become mail links, either written out as <someone@example.com> or
+with your own text: [Contact us](mailto:someone@example.com?subject=Marked%20Space)
+
 ![Alt text](image.png "A rusty crustation")
 
 ![External Image](http://confluence.atlassian.com/images/logo/confluence_48_trans.png "An external image")

--- a/src/attachments.rs
+++ b/src/attachments.rs
@@ -64,7 +64,9 @@ pub fn render_link_enter(nl: &NodeLink, output: &mut WriteWithLast) -> io::Resul
         output.write_all(format!(" ac:title=\"{}\"", nl.title).as_bytes())?;
     }
     output.write_all(b">")?;
-    if nl.url.contains("://") {
+    // Same test as the one that decides whether to collect the image as an attachment, so the
+    // renderer can't reference an attachment that was never uploaded.
+    if !LocalLink::is_local_link(&nl.url) {
         output.write_all(b"<ri:url ri:value=\"")?;
         escape_href(output, nl.url.as_bytes())?;
     } else {
@@ -244,6 +246,23 @@ mod test {
 
         assert_eq!(String::from_utf8(cursor.into_inner()).unwrap(),
             "<ac:image ac:align=\"center\" ac:title=\"some title\"><ri:attachment ri:filename=\"assets_image.png\"/></ac:image>"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_renders_images_with_a_scheme_as_external() -> TestResult {
+        // Images are classified with the same test as links, so a url that isn't collected as an
+        // attachment isn't rendered as one either.
+        let rendered_page = test_render("# Title\n\n![logo](ac:image-macro)")?;
+
+        assert!(
+            rendered_page
+                .content
+                .contains(r#"<ri:url ri:value="ac:image-macro"/>"#),
+            "expected {} to reference the url, not an attachment",
+            rendered_page.content
         );
 
         Ok(())

--- a/src/link_generator.rs
+++ b/src/link_generator.rs
@@ -9,7 +9,7 @@ use comrak::nodes::NodeLink;
 
 use crate::{
     confluence_page::{ConfluenceNode, ConfluenceNodeType, ConfluencePageData},
-    confluence_storage_renderer::ConfluenceStorageRenderer,
+    confluence_storage_renderer::{escape_href, ConfluenceStorageRenderer},
     console::print_warning,
     error::{ConfluenceError, Result},
     local_link::LocalLink,
@@ -163,9 +163,11 @@ impl LinkGenerator {
         confluence_formatter: &mut ConfluenceStorageRenderer,
         no_children: bool,
     ) -> io::Result<()> {
-        if nl.url.contains("://") {
+        // Links Confluence resolves itself: external URLs, and mailto: links which it renders
+        // as an ordinary anchor.
+        if !LocalLink::is_local_link(&nl.url) {
             confluence_formatter.output.write_all(b"<a href=\"")?;
-            confluence_formatter.output.write_all(nl.url.as_bytes())?;
+            escape_href(&mut confluence_formatter.output, nl.url.as_bytes())?;
             confluence_formatter.output.write_all(b"\">")?;
             return Ok(());
         }
@@ -222,7 +224,7 @@ impl LinkGenerator {
         nl: &NodeLink,
         confluence_formatter: &mut ConfluenceStorageRenderer,
     ) -> io::Result<()> {
-        if nl.url.contains("://") {
+        if !LocalLink::is_local_link(&nl.url) {
             confluence_formatter.output.write_all(b"</a>")?;
         } else {
             let local_link = relative_local_link(nl, confluence_formatter);

--- a/src/local_link.rs
+++ b/src/local_link.rs
@@ -39,8 +39,12 @@ pub fn simplify_path(p: &Path) -> Result<PathBuf> {
 
 impl LocalLink {
     // TODO: make from_str return an optional local link?
+
+    /// Links that resolve against the files in the space, as opposed to ones Confluence follows
+    /// on its own: anything with a scheme (`https://`, `mailto:`) or one of Confluence's own
+    /// `ac:` links is left alone.
     pub fn is_local_link(text: &str) -> bool {
-        !(text.starts_with("http://") || text.starts_with("https://") || text.starts_with("ac:"))
+        !(text.contains("://") || text.starts_with("mailto:") || text.starts_with("ac:"))
     }
 
     fn split_anchor(text: &str, page_path: &Path) -> Result<(PathBuf, Option<String>)> {
@@ -116,6 +120,25 @@ mod test {
     use crate::error::TestResult;
 
     use super::LocalLink;
+
+    #[test]
+    fn it_only_treats_schemeless_links_as_local() -> TestResult {
+        assert!(LocalLink::is_local_link("test.md"));
+        assert!(LocalLink::is_local_link("../test.md#anchor"));
+        assert!(LocalLink::is_local_link("#anchor"));
+        assert!(LocalLink::is_local_link("assets/image.png"));
+
+        assert!(!LocalLink::is_local_link("http://example.com"));
+        assert!(!LocalLink::is_local_link("https://example.com"));
+        assert!(!LocalLink::is_local_link("ftp://example.com/file.txt"));
+        assert!(!LocalLink::is_local_link("ac:something"));
+        assert!(!LocalLink::is_local_link("mailto:user@example.com"));
+        assert!(!LocalLink::is_local_link(
+            "mailto:user@example.com?subject=Hello"
+        ));
+
+        Ok(())
+    }
 
     #[test]
     fn it_parses_local_links_without_anchor() -> TestResult {

--- a/src/local_link.rs
+++ b/src/local_link.rs
@@ -40,9 +40,12 @@ pub fn simplify_path(p: &Path) -> Result<PathBuf> {
 impl LocalLink {
     // TODO: make from_str return an optional local link?
 
-    /// Links that resolve against the files in the space, as opposed to ones Confluence follows
-    /// on its own: anything with a scheme (`https://`, `mailto:`) or one of Confluence's own
-    /// `ac:` links is left alone.
+    /// Whether a link resolves against the files in the space, rather than being one Confluence
+    /// follows itself. `://` covers remote urls whatever their scheme; `mailto:` has to be named
+    /// separately because it has no authority part, and `ac:` is Confluence's own link scheme.
+    ///
+    /// Everything that classifies a link - rendering, and collecting attachments and page links -
+    /// goes through here, so a link can't render one way and be collected another.
     pub fn is_local_link(text: &str) -> bool {
         !(text.contains("://") || text.starts_with("mailto:") || text.starts_with("ac:"))
     }

--- a/src/markdown_page.rs
+++ b/src/markdown_page.rs
@@ -590,6 +590,89 @@ mod tests {
     }
 
     #[test]
+    fn it_renders_mailto_links() -> TestResult {
+        let arena = Arena::<AstNode>::new();
+        let page = page_from_str(
+            "page.md",
+            "# My Page Title\n\n[Contact](mailto:user@example.com)",
+            &arena,
+        )?;
+        let html_content = page.to_html_string(&LinkGenerator::default_test())?;
+
+        assert!(
+            html_content.contains(r#"<a href="mailto:user@example.com">Contact</a>"#),
+            "expected {} to contain a mailto anchor",
+            html_content
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_renders_email_autolinks() -> TestResult {
+        let arena = Arena::<AstNode>::new();
+        let page = page_from_str(
+            "page.md",
+            "# My Page Title\n\nMail me at <user@example.com>.",
+            &arena,
+        )?;
+        let html_content = page.to_html_string(&LinkGenerator::default_test())?;
+
+        assert!(
+            html_content.contains(r#"<a href="mailto:user@example.com">user@example.com</a>"#),
+            "expected {} to contain a mailto anchor",
+            html_content
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_escapes_mailto_link_parameters() -> TestResult {
+        // Storage format is XHTML, so a bare & in the href would fail to parse.
+        let arena = Arena::<AstNode>::new();
+        let page = page_from_str(
+            "page.md",
+            "# My Page Title\n\n[Contact](mailto:user@example.com?subject=Hello&body=Hi)",
+            &arena,
+        )?;
+        let html_content = page.to_html_string(&LinkGenerator::default_test())?;
+
+        assert!(
+            html_content.contains(
+                r#"<a href="mailto:user@example.com?subject=Hello&amp;body=Hi">Contact</a>"#
+            ),
+            "expected {} to contain an escaped mailto anchor",
+            html_content
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_does_not_treat_mailto_links_as_local() -> TestResult {
+        let arena = Arena::<AstNode>::new();
+        let page = page_from_str(
+            "page.md",
+            "# My Page Title\n\n[Contact](mailto:user@example.com) or <other@example.com>",
+            &arena,
+        )?;
+
+        assert!(
+            page.attachments.is_empty(),
+            "mailto links should not be collected as attachments: {:?}",
+            page.attachments
+        );
+        assert!(
+            page.local_links.is_empty(),
+            "mailto links should not be collected as local links: {:?}",
+            page.local_links
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn it_renders_templates() -> TestResult {
         let arena = Arena::<AstNode>::new();
         let markdown_content = "# compulsory title\n{{filename}}";


### PR DESCRIPTION
Both forms of email link were being resolved against the files in the space, because `is_local_link()` only knew about `http://`, `https://` and `ac:`.

`[Contact](mailto:user@example.com)` and the autolink form `<user@example.com>` (CommonMark gives that one a `mailto:` url too) came out as an attachment macro:

```html
<ac:structured-macro ac:name="view-file"><ac:parameter ac:name="name"><ri:attachment ri:filename="mailto:user@example.com"/></ac:parameter></ac:structured-macro>
```

and were collected as page attachments, so the sync then failed looking for a file named after the address. They now render as the anchor Confluence storage format expects:

```html
<a href="mailto:user@example.com">Contact</a>
```

## One test for remote links, used everywhere

`://` stays the test for a remote url — it covers any scheme, not just http(s). `mailto:` has to be named separately because it has no authority part, and `ac:` is Confluence's own scheme:

```rust
!(text.contains("://") || text.starts_with("mailto:") || text.starts_with("ac:"))
```

Every site that classifies a link now calls `is_local_link()`. Two had grown their own copies, and both disagreed with the collection code in a way that produced broken output:

| Site | Was | Effect |
| --- | --- | --- |
| `link_generator::enter`/`exit` | `url.contains("://")` | an `ftp://` link rendered as an anchor but was still collected as an attachment, so the sync failed on a link that looked fine |
| `attachments::render_link_enter` (images) | `url.contains("://")` | an `ac:` image url was never collected as an attachment but still rendered as `<ri:attachment>`, pointing at a file that was never uploaded |

`page_covers` already used the shared test.

## Escaping

Link hrefs are escaped now, so a `mailto:` carrying a subject or body can't break the page — a bare `&` in an attribute isn't valid XHTML, and storage format is XHTML. This is the same `escape_href` the renderer already applies to remote image urls.

## Testing

Six new tests. The rendering ones were run against the old code first to confirm the failure mode (attachment macro, plus collection as an attachment):

- `[Contact](mailto:…)` renders as an anchor
- `<user@example.com>` renders as an anchor
- neither is collected as an attachment or a local link
- `?subject=…&body=…` comes out with `&amp;`
- an image url with a scheme renders as `<ri:url>`, not `<ri:attachment>`
- `is_local_link` unit table: relative paths and anchors are local; `http`, `https`, `ftp`, `ac:` and `mailto:` are not

156 tests pass. `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

Documented in the example space's formatting page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6bpksyMe8DQdqZvm6uGdz)_