### PR TITLE
Put the cargo-deny audit back in CI

### DIFF
--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check Format
         run: cargo fmt --all -- --check
-  # audit:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: EmbarkStudios/cargo-deny-action@v2
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
   build:
     name: "Build"
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "saphyr-serde"
 version = "0.1.0"
-source = "git+https://github.com/james-allan-lloyd/saphyr-serde.git#9aa5721470837f3b5d8b206bca53083a24783ce7"
+source = "git+https://github.com/james-allan-lloyd/saphyr-serde.git#17c74b4602f8c63c28c350881d649906dda43750"
 dependencies = [
  "regex",
  "saphyr-parser",

--- a/deny.toml
+++ b/deny.toml
@@ -1,283 +1,61 @@
-# This template contains all of the possible sections and their default values
+# Configuration for cargo-deny, run in CI by the audit job in rust-pr.yml.
+# Field reference: https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+#
+# Replaces the old template, which no longer deserialized: several of the fields
+# it set (advisories.vulnerability, advisories.notice, licenses.copyleft,
+# licenses.allow-osi-fsf-free) were removed in cargo-deny 0.14.
 
-# Note that all fields that take a lint level have these possible values:
-# * deny - An error will be produced and the check will fail
-# * warn - A warning will be produced, but the check will not fail
-# * allow - No warning or error will be produced, though in some cases a note
-# will be
-
-# The values provided in this template are the default values that will be used
-# when any section or field is not specified in your own configuration
-
-# Root options
-
-# If 1 or more target triples (and optionally, target_features) are specified,
-# only the specified targets will be checked when running `cargo deny check`.
-# This means, if a particular package is only ever used as a target specific
-# dependency, such as, for example, the `nix` crate only being used via the
-# `target_family = "unix"` configuration, that only having windows targets in
-# this list would mean the nix crate, as well as any of its exclusive
-# dependencies not shared by any other crates, would be ignored, as the target
-# list here is effectively saying which targets you are building for.
-targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #{ triple = "x86_64-unknown-linux-musl" },
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
-]
-# When creating the dependency graph used as the source of truth when checks are
-# executed, this field can be used to prune crates from the graph, removing them
-# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
-# is pruned from the graph, all of its dependencies will also be pruned unless
-# they are connected to another crate in the graph that hasn't been pruned,
-# so it should be used with care. The identifiers are [Package ID Specifications]
-# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
-#exclude = []
-# If true, metadata will be collected with `--all-features`. Note that this can't
-# be toggled off if true, if you want to conditionally enable `--all-features` it
-# is recommended to pass `--all-features` on the cmd line instead
-all-features = false
-# If true, metadata will be collected with `--no-default-features`. The same
-# caveat with `all-features` applies
-no-default-features = false
-# If set, these feature will be enabled when collecting metadata. If `--features`
-# is specified on the cmd line they will take precedence over this option.
-#features = []
-# When outputting inclusion graphs in diagnostics that include features, this
-# option can be used to specify the depth at which feature edges will be added.
-# This option is included since the graphs can be quite large and the addition
-# of features from the crate(s) to all of the graph roots can be far too verbose.
-# This option can be overridden via `--feature-depth` on the cmd line
-feature-depth = 1
-
-# This section is considered when running `cargo deny check advisories`
-# More documentation for the advisories section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-# The path where the advisory database is cloned/fetched into
 db-path = "~/.cargo/advisory-db"
-# The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "warn"
-# The lint level for crates that have been yanked from their source registry
-yanked = "warn"
-# The lint level for crates with security notices.
-notice = "warn"
-# A list of advisory IDs to ignore. Note that ignored advisories will still
-# output a note when they are encountered.
-ignore = [
-    #"RUSTSEC-0000-0000",
-]
-# Threshold for security vulnerabilities, any vulnerability with a CVSS score
-# lower than the range specified will be ignored. Note that ignored advisories
-# will still output a note when they are encountered.
-# * None - CVSS Score 0.0
-# * Low - CVSS Score 0.1 - 3.9
-# * Medium - CVSS Score 4.0 - 6.9
-# * High - CVSS Score 7.0 - 8.9
-# * Critical - CVSS Score 9.0 - 10.0
-#severity-threshold =
-
-# If this is true, then cargo deny will use the git executable to fetch advisory database.
-# If this is false, then it uses a built-in git library.
-# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
-# See Git Authentication for more information about setting up git authentication.
-#git-fetch-with-cli = true
-
-# This section is considered when running `cargo deny check licenses`
-# More documentation for the licenses section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
-# [licenses]
-# # The lint level for crates which do not have a detectable license
-# unlicensed = "deny"
-# # List of explicitly allowed licenses
-# # See https://spdx.org/licenses/ for list of possible licenses
-# # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-# allow = [
-#     "MIT",
-#     "Apache-2.0",
-#     "Apache-2.0 WITH LLVM-exception",
-#     "BSD-2-Clause",
-#     "BSD-3-Clause",
-# ]
-# # List of explicitly disallowed licenses
-# # See https://spdx.org/licenses/ for list of possible licenses
-# # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-# deny = [
-#     #"Nokia",
-# ]
-# # Lint level for licenses considered copyleft
-# copyleft = "warn"
-# # Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# # * both - The license will be approved if it is both OSI-approved *AND* FSF
-# # * either - The license will be approved if it is either OSI-approved *OR* FSF
-# # * osi - The license will be approved if it is OSI approved
-# # * fsf - The license will be approved if it is FSF Free
-# # * osi-only - The license will be approved if it is OSI-approved *AND NOT* FSF
-# # * fsf-only - The license will be approved if it is FSF *AND NOT* OSI-approved
-# # * neither - This predicate is ignored and the default lint level is used
-# allow-osi-fsf-free = "neither"
-# # Lint level used when no other predicates are matched
-# # 1. License isn't in the allow or deny lists
-# # 2. License isn't copyleft
-# # 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-# default = "deny"
-# # The confidence threshold for detecting a license from license text.
-# # The higher the value, the more closely the license text must be to the
-# # canonical license text of a valid SPDX license file.
-# # [possible values: any between 0.0 and 1.0].
-# confidence-threshold = 0.8
-# # Allow 1 or more licenses on a per-crate basis, so that particular licenses
-# # aren't accepted for every possible crate as with the normal allow list
-# exceptions = [
-#     # Each entry is the crate and version constraint, and its specific allow
-#     # list
-#     #{ allow = ["Zlib"], name = "adler32", version = "*" },
-# ]
-
-# # Some crates don't have (easily) machine readable licensing information,
-# # adding a clarification entry for it allows you to manually specify the
-# # licensing information
-# #[[licenses.clarify]]
-# # The name of the crate the clarification applies to
-# #name = "ring"
-# # The optional version constraint for the crate
-# #version = "*"
-# # The SPDX expression for the license requirements of the crate
-# #expression = "MIT AND ISC AND OpenSSL"
-# # One or more files in the crate's source used as the "source of truth" for
-# # the license expression. If the contents match, the clarification will be used
-# # when running the license check, otherwise the clarification will be ignored
-# # and the crate will be checked normally, which may produce warnings or errors
-# # depending on the rest of your configuration
-# #license-files = [
-#     # Each entry is a crate relative path, and the (opaque) hash of its contents
-#     #{ path = "LICENSE", hash = 0xbd0eed23 }
-# #]
+# Security advisories and yanked crates always fail the check. Unmaintained ones
+# are only reported for crates we depend on directly, where we can actually act:
+# an unmaintained crate deep in the tree usually has no upgrade to take, and
+# would just wedge CI until upstream moves.
+unmaintained = "workspace"
+yanked = "deny"
+ignore = []
 
 [licenses]
-allow-osi-fsf-free = "either"
-copyleft = "deny"
+# The licences actually in the tree: permissive, plus MPL-2.0 (weak copyleft,
+# arrives with colored) and CDLA-Permissive-2.0 (webpki-roots 1.0, which is a
+# data package - the Mozilla root store). This is the set the old config let
+# through via `allow-osi-fsf-free = "either"`, written out.
+#
+# r-efi is LGPL-2.1-or-later as one arm of "MIT OR Apache-2.0 OR
+# LGPL-2.1-or-later", so allowing MIT satisfies it and the copyleft arm is
+# never taken.
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CDLA-Permissive-2.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",
+  "Unicode-3.0",
+  "Unlicense",
+  "Zlib",
+]
+confidence-threshold = 0.8
 
+# ring's licensing isn't machine readable
 [[licenses.clarify]]
 name = "ring"
 version = "*"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
-[licenses.private]
-# If true, ignores workspace crates that aren't published, or are only
-# published to private registries.
-# To see how to mark a crate as unpublished (to the official registry),
-# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
-ignore = false
-# One or more private registries that you might publish crates to, if a crate
-# is only published to private registries, and ignore is true, the crate will
-# not have its license(s) checked
-registries = [
-    #"https://sekretz.com/registry
-]
 
-# This section is considered when running `cargo deny check bans`.
-# More documentation about the 'bans' section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
-# Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
-# Lint level for when a crate version requirement is `*`
 wildcards = "allow"
-# The graph highlighting used when creating dotgraphs for crates
-# with multiple versions
-# * lowest-version - The path to the lowest versioned duplicate is highlighted
-# * simplest-path - The path to the version with the fewest edges is highlighted
-# * all - Both lowest-version and simplest-path are used
 highlight = "all"
-# The default lint level for `default` features for crates that are members of
-# the workspace that is being checked. This can be overridden by allowing/denying
-# `default` on a crate-by-crate basis if desired.
-workspace-default-features = "allow"
-# The default lint level for `default` features for external crates that are not
-# members of the workspace. This can be overridden by allowing/denying `default`
-# on a crate-by-crate basis if desired.
-external-default-features = "allow"
-# List of crates that are allowed. Use with care!
-allow = [
-    #{ name = "ansi_term", version = "=0.11.0" },
-]
-# List of crates to deny
-deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
-]
 
-# List of features to allow/deny
-# Each entry the name of a crate and a version range. If version is
-# not specified, all versions will be matched.
-#[[bans.features]]
-#name = "reqwest"
-# Features to not allow
-#deny = ["json"]
-# Features to allow
-#allow = [
-#    "rustls",
-#    "__rustls",
-#    "__tls",
-#    "hyper-rustls",
-#    "rustls",
-#    "rustls-pemfile",
-#    "rustls-tls-webpki-roots",
-#    "tokio-rustls",
-#    "webpki-roots",
-#]
-# If true, the allowed features must exactly match the enabled feature set. If
-# this is set there is no point setting `deny`
-#exact = true
-
-# Certain crates/versions that will be skipped when doing duplicate detection.
-skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
-]
-# Similarly to `skip` allows you to skip certain crates during duplicate
-# detection. Unlike skip, it also includes the entire tree of transitive
-# dependencies starting at the specified crate, up to a certain depth, which is
-# by default infinite.
-skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
-]
-
-# This section is considered when running `cargo deny check sources`.
-# More documentation about the 'sources' section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
 [sources]
-# Lint level for what to happen when a crate from a crate registry that is not
-# in the allow list is encountered
-unknown-registry = "warn"
-# Lint level for what to happen when a crate from a git repository that is not
-# in the allow list is encountered
-unknown-git = "warn"
-# List of URLs for allowed crate registries. Defaults to the crates.io index
-# if not specified. If it is specified but empty, no registries are allowed.
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# List of URLs for allowed Git repositories
-allow-git = []
-
-# [sources.allow-org]
-# # 1 or more github.com organizations to allow git sources for
-# github = [""]
-# # 1 or more gitlab.com organizations to allow git sources for
-# gitlab = [""]
-# # 1 or more bitbucket.org organizations to allow git sources for
-# bitbucket = [""]
+allow-git = ["https://github.com/james-allan-lloyd/saphyr-serde.git"]


### PR DESCRIPTION
The audit job in `rust-pr.yml` was commented out, and `deny.toml` no longer deserialized at all — it's the old template, and several of the fields it sets were removed in cargo-deny 0.14:

```
error[unexpected-value]: expected '["all", "workspace", "transitive", "none"]'
   ┌─ deny.toml:67:17
67 │ unmaintained = "warn"
```

`advisories.vulnerability`, `advisories.notice`, `licenses.copyleft` and `licenses.allow-osi-fsf-free` are gone too. So nothing has been checking the dependency tree, and the job wouldn't have worked even if it had been enabled.

## Turning it back on found a live vulnerability

```
error[vulnerability]: Reachable panic in certificate revocation list parsing
    ├ ID: RUSTSEC-2026-0104
    ├ rustls-webpki v0.103.1
      └── rustls v0.23.26
          ├── hyper-rustls v0.27.5
          │   └── reqwest v0.12.15 → marked-space
```

A panic reachable while parsing a certificate revocation list, **before the CRL's signature is verified**. Fixed in 0.103.13. #93 carried 0.103.14, so merging it closed this — which makes that dependency update a security fix rather than housekeeping.

## The config

Rewritten against the current schema, keeping the policy the old one effectively had:

- **licences** — the set actually in the tree, written out: permissive, plus `MPL-2.0` (weak copyleft, via `colored`) and `CDLA-Permissive-2.0`. That last one is new: `webpki-roots` **relicensed at 1.0**, from MPL-2.0 to CDLA-Permissive-2.0, which suits it since the Mozilla root store is a data package. `r-efi` shows as LGPL-2.1-or-later but that's one arm of `MIT OR Apache-2.0 OR LGPL-2.1-or-later`, so allowing MIT satisfies it and the copyleft arm is never taken.
- **unmaintained** — `"workspace"` rather than the whole tree. One buried deep usually has no upgrade to take and would just wedge CI until upstream moves. Current example: [RUSTSEC-2025-0057](https://rustsec.org/advisories/RUSTSEC-2025-0057) (`fxhash`) via `scraper`, a dev-dependency with no newer release to move to.
- **sources** — `unknown-git` is now `deny` with the `saphyr-serde` URL allowed explicitly, so a new git dependency has to be a deliberate choice.

## Licences are checked too

This also picks up the `saphyr-serde` revision that declares `license = "MIT OR Apache-2.0"` (`9aa57214` → `17c74b46`), so the job runs the full `cargo deny check` — advisories, bans, licences and sources — rather than the three it was scoped to while that crate was unlicensed.

## Verified

With cargo-deny 0.20.2 against this branch's lockfile:

```
advisories ok, bans ok, licenses ok, sources ok
```

and on the new saphyr-serde revision: 156 tests pass, `clippy --all-targets --all-features -- -D warnings` clean, `fmt --check` clean. `actionlint` clean on the changed job.