### PR TITLE
Move the workflow actions onto the Node 24 runtime

### DIFF
--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -10,13 +10,13 @@ jobs:
       CARGO_TERM_COLOR: always
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check Format
         run: cargo fmt --all -- --check
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: EmbarkStudios/cargo-deny-action@v2
   build:
     name: "Build"
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate example space using github action
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Point the action at the image built for this pull request
         env:
           IMAGE: jamesallanlloyd/marked-space:pr-${{ github.event.number }}

--- a/.github/workflows/rust-prerelease.yml
+++ b/.github/workflows/rust-prerelease.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate example space using github action
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Point the action at the image just built from main
         env:
           IMAGE: jamesallanlloyd/marked-space:latest
@@ -53,21 +53,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download ubuntu
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ubuntu-latest
 
       - name: Download windows
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: windows-latest
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      # marvinpinto/action-automatic-releases moved the `latest` tag itself. The releases API
+      # only creates a tag when it's missing, so without this the Development Build would stay
+      # pinned to wherever `latest` already points. Falls back to creating it if it's ever
+      # deleted.
+      - name: Point the latest tag at this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          gh api -X PATCH "repos/$REPO/git/refs/tags/latest" -f sha="$SHA" -F force=true ||
+            gh api -X POST "repos/$REPO/git/refs" -f ref="refs/tags/latest" -f sha="$SHA"
+
+      - uses: softprops/action-gh-release@v3
         with:
-          repo_token: ${{ github.token }}
-          automatic_release_tag: latest
+          tag_name: latest
           prerelease: true
-          title: Development Build
+          name: Development Build
           files: |
             marked-space
             marked-space.exe

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -32,17 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download ubuntu
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ubuntu-latest
 
       - name: Download windows
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: windows-latest
 
       - name: Upload binaries to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             marked-space

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -17,9 +17,9 @@ jobs:
   test:
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         continue-on-error: false
         with:
           path: |
@@ -41,9 +41,9 @@ jobs:
     needs:
       - test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         continue-on-error: false
         with:
           path: |
@@ -57,7 +57,7 @@ jobs:
       - name: Build release
         run: cargo build --release
       - name: "Upload Artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.os }}
           path: target/release/marked-space${{ inputs.os == 'windows-latest' && '.exe' || '' }}

--- a/.github/workflows/shared-docker-publish.yml
+++ b/.github/workflows/shared-docker-publish.yml
@@ -40,28 +40,28 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           version: latest
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -78,7 +78,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -92,25 +92,25 @@ jobs:
       - docker-build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |


### PR DESCRIPTION
> Stacked on #94 so the audit job's `checkout` gets bumped with everything else. GitHub will retarget this to `main` once #94 merges.

Every run logs that its actions are being forced onto Node 24 because their `action.yml` still declares `node20`. Each of these needed a major version to reach a node24 release:

| Action | Was | Now | Latest available |
| --- | --- | --- | --- |
| `actions/checkout` | v3 *and* v4 | **v5** | v5 |
| `actions/cache` | v3 | **v5** | v5 |
| `actions/upload-artifact` | v4 | **v6** | v7.0.1 |
| `actions/download-artifact` | v4 | **v7** | v8.0.1 |
| `docker/login-action` | v3 | **v4** | v4.6.0 |
| `docker/metadata-action` | v5 | **v6** | v6.2.0 |
| `docker/setup-buildx-action` | v3 | **v4** | v4.2.0 |
| `docker/setup-qemu-action` | v3 | **v4** | v4.2.0 |
| `docker/build-push-action` | v6 | **v7** | v7.3.0 |
| `softprops/action-gh-release` | v2 | **v3** | v3.0.2 |

`EmbarkStudios/cargo-deny-action` is a Docker action (`using: "docker"`), so the runtime deprecation doesn't apply to it.

**The artifact actions stop at the first node24 release rather than the newest.** `download-artifact` v8 turns a hash mismatch from a warning into an error and migrates to ESM — not worth taking blind on a workflow that only runs on a tag. The `name` input this repo uses behaves identically across every version in that range (v5's path change only affected downloads *by ID*).

## The dead one

`marvinpinto/action-automatic-releases` had no version to move to: no release since 2021, and it was pinned to `@latest` — a mutable tag, so the prerelease job ran whatever that repository happened to be serving at the time. Replaced with `softprops/action-gh-release@v3`, which `rust-release.yml` already uses, so it's one fewer third-party action overall.

**One catch that needed handling.** The old action moved the `latest` tag itself. `action-gh-release` doesn't, and the releases API only creates a tag when it's missing — and `latest` already exists in this repo. A naive swap would have left the Development Build permanently pinned to whatever commit that tag currently names, silently, while still publishing fresh binaries against it. So the tag is now moved explicitly first:

```yaml
- name: Point the latest tag at this commit
  run: |
    gh api -X PATCH "repos/$REPO/git/refs/tags/latest" -f sha="$SHA" -F force=true ||
      gh api -X POST "repos/$REPO/git/refs" -f ref="refs/tags/latest" -f sha="$SHA"
```

with the `POST` fallback covering the tag being deleted at some point. The job already has `permissions: write-all`, and `gh` is preinstalled on the runners.

## Verification, and its limits

`actionlint` + `shellcheck`: the "runner too old" warnings it used to report for `checkout@v3`, `cache@v3` and `marvinpinto` are **gone**, and the new step is clean. The three shellcheck findings still reported in `shared-docker-publish.yml` predate this PR (the deliberate word splitting in the `imagetools create` call and an unquoted `$GITHUB_ENV`).

What this PR's own CI exercises: `checkout`, `cache`, both artifact actions, all five docker actions, and `cargo-deny-action`. So most of the table is covered on the PR itself.

What it doesn't:

- **the prerelease path** — first exercised on merge to main, which is where the `latest` tag move and `action-gh-release@v3` get their real test. Worth glancing at the Development Build release afterwards to confirm it points at the merge commit.
- **`rust-release.yml`** — only runs on a `v*` tag, so `download-artifact@v7` and `action-gh-release@v3` there are unexercised until the next release. Given 1.0.5 just went out, that's a while away; the inputs used (`files`, `draft`) are unchanged between v2 and v3.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6bpksyMe8DQdqZvm6uGdz)_